### PR TITLE
add thumbnail image

### DIFF
--- a/common/models/published-data.json
+++ b/common/models/published-data.json
@@ -52,6 +52,11 @@
             "required": true,
             "description": "Abstract text for published datasets"
         },
+        "thumbnail": {
+            "type": "string",
+            "required": true,
+            "description": "Small, less than 16 MB base 64 image preview of dataset"
+        },
         "resourceType": {
             "type": "string",
             "required": true,


### PR DESCRIPTION
## Description
Add thumbnail image to published data 

## Motivation 

Adds a thumbnail image to catamel published data to show up in landing pager server
preview page image for the DOI landing page

## Fixes:

* 
*  

## Changes:

* 
* 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
