### PR TITLE
Add support for datasets whose files are stored on decentral storage …

### DIFF
--- a/common/models/dataset-lifecycle.json
+++ b/common/models/dataset-lifecycle.json
@@ -51,6 +51,10 @@
             "type": "date",
             "description": "Day when dataset is supposed to become public according to data policy"
         },
+        "isOnCentralDisk": {
+            "type": "boolean",
+            "description": "Flag which is true, if full dataset is available on central fileserver. If false data needs to be copied from decentral storage place to  a cache server before the ingest. This information needs to be transferred to the archive system at archive time"
+        },
         "isOnDisk": {
             "type": "boolean",
             "description": "Flag which is true, if full dataset is available on disk. Warning: will be obsoleted in coming versions"

--- a/common/models/dataset.json
+++ b/common/models/dataset.json
@@ -134,7 +134,7 @@
             "permission": "ALLOW"
         },
         {
-            "accessType": "READ",
+            "accessType": "*",
             "principalType": "ROLE",
             "principalId": "$authenticated",
             "permission": "ALLOW"


### PR DESCRIPTION
## Description
 Add support for datasets whose files are stored on decentral storage units

## Motivation 
DatasetLifecycle needs to carry one more field of information to allow the archive system to find the files

