### PR TITLE
WIP: Validates uniqueness of pid for all dataset models

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -13,6 +13,8 @@ module.exports = function(Dataset) {
     var app = require('../../server/server');
     // make sure that all times are UTC
 
+    Dataset.validatesUniquenessOf('pid');
+
     // put
     Dataset.beforeRemote('replaceOrCreate', function(ctx, instance, next) {
         utils.updateTimesToUTC(['creationTime'], ctx.args.data);

--- a/common/models/derived-dataset.js
+++ b/common/models/derived-dataset.js
@@ -3,6 +3,8 @@
 module.exports = function (Deriveddataset) {
     var utils = require('./utils');
 
+    Deriveddataset.validatesUniquenessOf('pid');
+
     // filter on dataset type (raw, derived etc)
     Deriveddataset.observe('access', function (ctx, next) {
         var typeCondition = {

--- a/common/models/raw-dataset.js
+++ b/common/models/raw-dataset.js
@@ -2,6 +2,7 @@
 var utils = require('./utils');
 
 module.exports = function(Rawdataset) {
+  Rawdataset.validatesUniquenessOf('pid');
 
   // filter on dataset type (raw, derived etc)
   Rawdataset.observe('access', function(ctx, next) {


### PR DESCRIPTION
## Description

Adds uniqueness on PIDs for all dataset models.

## Motivation 

Previously, if a dataset with an already existing PID was POSTed, an exception would be raised from MongoDB. This would result in an anonymous 500 error to the API consumer. This PR adds proper validation in the application layer (Loopback).

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?
