### PR TITLE
Made loopback-connector-kafka an optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,12 @@
                 "through": ">=2.2.7 <3"
             }
         },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "optional": true
+        },
         "accept-language": {
             "version": "3.0.18",
             "resolved": "https://registry.npmjs.org/accept-language/-/accept-language-3.0.18.tgz",
@@ -281,6 +287,11 @@
                 }
             }
         },
+        "ansi": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+        },
         "ansi-escapes": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -299,6 +310,16 @@
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
             "dev": true
         },
+        "are-we-there-yet": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+            "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+            "optional": true,
+            "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.0 || ^1.1.13"
+            }
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -311,6 +332,16 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "array-index": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+            "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+            "optional": true,
+            "requires": {
+                "debug": "^2.2.0",
+                "es6-symbol": "^3.0.2"
+            }
         },
         "asn1": {
             "version": "0.2.3",
@@ -397,6 +428,22 @@
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
             "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
         },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "optional": true,
+            "requires": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            }
+        },
+        "bindings": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+            "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
+            "optional": true
+        },
         "bitsyntax": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz",
@@ -412,6 +459,15 @@
             "requires": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
+            }
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "optional": true,
+            "requires": {
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -485,10 +541,31 @@
                 "ieee754": "^1.1.4"
             }
         },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "optional": true
+        },
         "buffer-more-ints": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
             "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw="
+        },
+        "buffermaker": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffermaker/-/buffermaker-1.2.0.tgz",
+            "integrity": "sha1-u3MlLsCIK3Y56bVWuCnav8LK4bo=",
+            "optional": true,
+            "requires": {
+                "long": "1.1.2"
+            }
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+            "optional": true
         },
         "bunyan": {
             "version": "1.8.12",
@@ -623,6 +700,23 @@
                         "qs": "^6.5.1",
                         "readable-stream": "^2.3.5"
                     }
+                }
+            }
+        },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "optional": true,
+            "requires": {
+                "traverse": ">=0.3.0 <0.4"
+            },
+            "dependencies": {
+                "traverse": {
+                    "version": "0.3.9",
+                    "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                    "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+                    "optional": true
                 }
             }
         },
@@ -864,6 +958,14 @@
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
         },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "requires": {
+                "es5-ext": "^0.10.9"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -914,6 +1016,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "optional": true
         },
         "depd": {
             "version": "1.1.2",
@@ -1043,6 +1151,26 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
             "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
         },
+        "es5-ext": {
+            "version": "0.10.46",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "es6-promise": {
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
@@ -1054,6 +1182,15 @@
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "requires": {
                 "es6-promise": "^4.0.3"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "escape-html": {
@@ -1503,6 +1640,17 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            }
+        },
         "functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -1515,6 +1663,19 @@
             "integrity": "sha512-ykVjThha+dGKAR/F31kCUxMn7vu1JrmUkDxMs+h7TvjGbQoNx29hsw618GQKm9eT4Qo6E+8zJAnt0BT3gMtggQ==",
             "requires": {
                 "swagger-client": "^3.8.3"
+            }
+        },
+        "gauge": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+            "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+            "optional": true,
+            "requires": {
+                "ansi": "^0.3.0",
+                "has-unicode": "^2.0.0",
+                "lodash.pad": "^4.1.0",
+                "lodash.padend": "^4.1.0",
+                "lodash.padstart": "^4.1.0"
             }
         },
         "get-func-name": {
@@ -1566,8 +1727,7 @@
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-            "dev": true
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
         },
         "har-schema": {
             "version": "2.0.0",
@@ -1597,6 +1757,12 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
+        },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "optional": true
         },
         "he": {
             "version": "1.1.1",
@@ -1954,6 +2120,38 @@
                 "verror": "1.10.0"
             }
         },
+        "kafka-node": {
+            "version": "0.2.30",
+            "resolved": "https://registry.npmjs.org/kafka-node/-/kafka-node-0.2.30.tgz",
+            "integrity": "sha1-rDJRny9in/7GLuZoY5U8sZ9WyPo=",
+            "optional": true,
+            "requires": {
+                "async": ">0.9 <2.0",
+                "binary": "~0.3.0",
+                "buffer-crc32": "~0.2.5",
+                "buffermaker": "~1.2.0",
+                "debug": "^2.1.3",
+                "lodash": ">3.0 <4.0",
+                "node-uuid": "~1.4.3",
+                "node-zookeeper-client": "~0.2.2",
+                "retry": "~0.6.1",
+                "snappy": "^4.0.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "optional": true
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                    "optional": true
+                }
+            }
+        },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -2020,6 +2218,30 @@
             "version": "4.17.10",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
             "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "lodash.pad": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+            "optional": true
+        },
+        "lodash.padend": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+            "optional": true
+        },
+        "lodash.padstart": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+            "optional": true
+        },
+        "long": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-1.1.2.tgz",
+            "integrity": "sha1-6u9ZUcp1UdlpJrgtokLbnWso+1M=",
+            "optional": true
         },
         "loopback": {
             "version": "3.24.0",
@@ -2235,6 +2457,15 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 }
+            }
+        },
+        "loopback-connector-kafka": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/loopback-connector-kafka/-/loopback-connector-kafka-0.2.1.tgz",
+            "integrity": "sha1-oRn7iqBmJzGMRlvsgX+nPbo43sE=",
+            "optional": true,
+            "requires": {
+                "kafka-node": "~0.2.1"
             }
         },
         "loopback-connector-mongodb": {
@@ -2793,6 +3024,11 @@
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+        },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2811,6 +3047,99 @@
             "requires": {
                 "encoding": "^0.1.11",
                 "is-stream": "^1.0.1"
+            }
+        },
+        "node-gyp": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
+            "integrity": "sha1-9d1WmXClCEZMw8Fdfp6NLehjjdU=",
+            "optional": true,
+            "requires": {
+                "fstream": "^1.0.0",
+                "glob": "3 || 4",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "1",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1",
+                "osenv": "0",
+                "path-array": "^1.0.0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "tar": "^2.0.0",
+                "which": "1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "4.5.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                    "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+                    "optional": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^2.0.1",
+                        "once": "^1.3.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "2.0.10",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                            "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                            "optional": true,
+                            "requires": {
+                                "brace-expansion": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "lru-cache": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                    "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+                    "optional": true,
+                    "requires": {
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "node-uuid": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+            "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+            "optional": true
+        },
+        "node-zookeeper-client": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.2.tgz",
+            "integrity": "sha1-CXvaAZme749gLOBotjJgAGnb9oU=",
+            "optional": true,
+            "requires": {
+                "async": "~0.2.7",
+                "underscore": "~1.4.4"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "optional": true
+                },
+                "underscore": {
+                    "version": "1.4.4",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+                    "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+                    "optional": true
+                }
             }
         },
         "nodemailer": {
@@ -2845,12 +3174,32 @@
             "resolved": "https://registry.npmjs.org/nodemailer-stub-transport/-/nodemailer-stub-transport-1.1.0.tgz",
             "integrity": "sha1-EUIdLWa07m9AU1T5FMH0ZB6ySw0="
         },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "optional": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
                 "path-key": "^2.0.0"
+            }
+        },
+        "npmlog": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+            "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+            "optional": true,
+            "requires": {
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
             }
         },
         "oauth": {
@@ -2940,6 +3289,12 @@
             "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
             "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
         },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "optional": true
+        },
         "os-locale": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -2953,8 +3308,17 @@
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "optional": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
         },
         "p-finally": {
             "version": "1.0.0",
@@ -3009,6 +3373,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
             "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+        },
+        "path-array": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+            "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+            "optional": true,
+            "requires": {
+                "array-index": "^1.0.0"
+            }
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -3276,11 +3649,16 @@
                 "signal-exit": "^3.0.2"
             }
         },
+        "retry": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+            "integrity": "sha1-/ckO7ZQ/3hG4k1VLjMY9DombqRg=",
+            "optional": true
+        },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "dev": true,
             "requires": {
                 "glob": "^7.0.5"
             }
@@ -3436,6 +3814,12 @@
                 "nanoid": "^2.0.0"
             }
         },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "optional": true
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -3457,6 +3841,25 @@
             "requires": {
                 "httpntlm": "1.6.1",
                 "nodemailer-shared": "1.1.0"
+            }
+        },
+        "snappy": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/snappy/-/snappy-4.1.2.tgz",
+            "integrity": "sha1-jN2cAIK5sF8VfsVv2RLBd0QBQps=",
+            "optional": true,
+            "requires": {
+                "bindings": "1.2.1",
+                "nan": "2.2.0",
+                "node-gyp": "3.2.1"
+            },
+            "dependencies": {
+                "nan": {
+                    "version": "2.2.0",
+                    "resolved": "http://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
+                    "integrity": "sha1-d5wHE1YpUDz2p7fmqrMwSbPDhTw=",
+                    "optional": true
+                }
             }
         },
         "sparse-bitfield": {
@@ -3800,6 +4203,17 @@
                     "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 }
+            }
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "optional": true,
+            "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "text-table": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "loopback-component-mq": "^2.2.5",
         "loopback-component-passport": "^3.10.0",
         "loopback-component-visualizer": "^1.2.1",
-        "loopback-connector-kafka": "^0.2.1",
         "loopback-connector-mongodb": "^3.9.2",
         "loopback-ds-timestamp-mixin": "^3.4.1",
         "moment": "^2.20.1",
@@ -34,6 +33,9 @@
         "serve-favicon": "2.5.0",
         "strong-error-handler": "3.2.0",
         "uuid": "^3.3.2"
+    },
+    "optionalDependencies": {
+        "loopback-connector-kafka": "^0.2.1"
     },
     "devDependencies": {
         "@mean-expert/loopback-sdk-builder": "^2.1.0",


### PR DESCRIPTION
## Description

Makes `loopback-connector-kafka` an optional dependency by moving it to `optionalDependencies` in `package.json`.

## Motivation 

Making a dependency optional means that `npm install` won't fail if the installation of the dependency in question fails for some reason. In this case it's desirable for two reasons:

1. `loopback-connector-kafka` is truly optional in the sense that not all facilities use it
2. This allows for building a Docker image of Catamel without python, resulting in a smaller image with less dependencies