### PR TITLE
Now the flags are explicitly transferred to dataset directly

### DIFF
--- a/common/models/dataset-lifecycle.js
+++ b/common/models/dataset-lifecycle.js
@@ -48,7 +48,8 @@ module.exports = function(Datasetlifecycle) {
         utils.addOwnerGroup(ctx, next)
     })
 
-    // transfer status flags to linked dataset
+    // transfer status flags to linked dataset.
+    // Warning: when using the updateAll API endpoint the context is missing !
     Datasetlifecycle.observe('after save', (ctx, next) => {
         var Dataset = app.models.Dataset
         var instance = ctx.instance

--- a/test/MessageHistory.js
+++ b/test/MessageHistory.js
@@ -255,19 +255,28 @@ describe('Test MessageHistory in jobs', () => {
             });
     });
 
-    it('Adds a new retrieve job request', function(done) {
+    it('Adds a new archive job request for same data which should fail', function(done) {
+        request(app)
+            .post('/api/v2/Jobs?access_token=' + accessTokenIngestor)
+            .send(testArchiveJob)
+            .set('Accept', 'application/json')
+            .expect(409)
+            .expect('Content-Type', /json/)
+            .end((err, res) => {
+                res.body.should.have.property('error');
+                done();
+            });
+    });
+
+    it('Adds a new retrieve job request on same dataset, which should fail as well because not yet retrievable', function(done) {
         request(app)
             .post('/api/v2/Jobs?access_token=' + accessTokenIngestor)
             .send(testRetrieveJob)
             .set('Accept', 'application/json')
-            .expect(200)
+            .expect(409)
             .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err)
-                    return done(err);
-                res.body.should.have.property('type').and.be.string;
-                idJob = res.body['id']
-                //console.log("Jobid:", idJob)
+            .end((err, res) => {
+                res.body.should.have.property('error');
                 done();
             });
     });

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -89,7 +89,7 @@
     {
         "method": "POST",
         "route": "Jobs",
-        "expect": 400,
+        "expect": 404,
         "authenticate": "admin",
         "body": {
             "emailJobInitiator": "scicatingestor@psi.ch",


### PR DESCRIPTION
## Description
Bugfix: due to loopback updateAll pecularities the archivable and retrievable flags were only passed from Jobs to DatasetLifecycle but not to Dataset

## Test cases
were updated

