### PR TITLE
If no proposal is linked to rawdataset try to fill one by common ownership

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -38,9 +38,9 @@ module.exports = function (Dataset) {
         if (ctx.instance) {
             if (ctx.isNewInstance) {
                 ctx.instance.pid = config.pidPrefix + '/' + ctx.instance.pid;
-                console.log(' new pid:', ctx.instance.pid);
+                console.log('New pid:', ctx.instance.pid);
             } else {
-                console.log('  unmodified pid:', ctx.instance.pid);
+                console.log('Unmodified pid:', ctx.instance.pid);
             }
             ctx.instance.version = p.version;
 

--- a/common/models/raw-dataset.js
+++ b/common/models/raw-dataset.js
@@ -2,6 +2,8 @@
 var utils = require('./utils');
 
 module.exports = function(Rawdataset) {
+  var app = require('../../server/server');
+
   Rawdataset.validatesUniquenessOf('pid');
 
   // filter on dataset type (raw, derived etc)
@@ -25,7 +27,20 @@ module.exports = function(Rawdataset) {
     if (ctx.instance) {
       ctx.instance.type = 'raw';
     }
-    next();
+    // check if proposal is linked, if not try to add one
+    if(!ctx.instance.proposalId){
+      var Proposal = app.models.Proposal
+      const filter = { where: { ownerGroup: ctx.instance.ownerGroup } };
+      Proposal.findOne(filter,ctx.options).then(instance => {
+        if(instance){
+          console.log("Appended Proposal "+instance.proposalId+" to rawdataset "+ctx.instance.pid)
+          ctx.instance.proposalId=instance.proposalId
+        } 
+        return next()
+      })
+    } else {
+      return next()
+    }
   });
 
   // put


### PR DESCRIPTION

## Description
Rawdatasets are automatically linked to Proposal data if the link information is missing. The implicit default assumption is, that the proposal and the raw dataset having the same ownerGroup belong together. If this is not the case one needs to make the linking explicitly (outside the API server)

## Motivation 
Try to centralize important business logic in order to simplify ingest tools.

## Tests included/Docs Updated?

- [*] Included for each change/fix?
- [*] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?
