### PR TITLE
Feature/riot link in logbook

### DIFF
--- a/common/models/logbook.json
+++ b/common/models/logbook.json
@@ -9,6 +9,9 @@
     "name": {
       "type": "string"
     },
+    "roomId": {
+      "type": "string"
+    },
     "messages": {
       "type": [
         "object"


### PR DESCRIPTION
## Description

Added roomId property to Logbook model

## Motivation 

Needed for displaying link to Riot chat room in Catanie Logbook Dashboard Component

## Changes:

* Added roomId property to Logbook model

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
