### PR TITLE
Removed id from model

### DIFF
--- a/common/models/logbook.json
+++ b/common/models/logbook.json
@@ -1,7 +1,7 @@
 {
   "name": "Logbook",
   "base": "Model",
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
@@ -10,7 +10,8 @@
       "type": "string"
     },
     "roomId": {
-      "type": "string"
+      "type": "string",
+      "id": true
     },
     "messages": {
       "type": [


### PR DESCRIPTION
## Description

Removes the idInjection and sets roomId to be the id of the logbook model

## Motivation 

The logbook model is not a persisted model, idInjection is redundant

## Changes:

* Set idInjection to false
* Set roomId to be the model id

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
