### PR TITLE
Changed sort delimiter

### DIFF
--- a/common/models/proposal.js
+++ b/common/models/proposal.js
@@ -140,7 +140,7 @@ module.exports = function(Proposal) {
                 const sortFields = limits.order.split(",");
                 let orders = [];
                 sortFields.forEach(field => {
-                    const parts = field.split(" ");
+                    const parts = field.split(":");
                     if (parts.length > 1) {
                         orders.push(parts[0] + " " + parts[1].toUpperCase());
                     } else {


### PR DESCRIPTION
## Description

Changed the proposal order delimiter from " " to ":"

## Motivation 

Fixes catanie proposals table sorting bug

## Changes:

* Changed the order delimiter in proposal fullquery from " " to ":"

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
