### PR TITLE
Changed fullquery to check that type is not object

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -1009,46 +1009,4 @@ module.exports = function(Dataset) {
             }
         ]
     });
-
-    Dataset.updateScientificMetadata = async function(dataset) {
-        await Dataset.updateAll(
-            { pid: dataset.pid },
-            { scientificMetadata: dataset.scientificMetadata }
-        );
-
-        const filter = {
-            include: ["datablocks", "origdatablocks", "attachments"]
-        };
-        return Dataset.findById(dataset.pid, filter);
-    };
-
-    Dataset.remoteMethod("updateScientificMetadata", {
-        accepts: [
-            {
-                arg: "dataset",
-                type: "Dataset",
-                required: true,
-                description:
-                    "The dataset for which to update scientificMetadata",
-                http: {
-                    source: "body"
-                }
-            }
-        ],
-        returns: [
-            {
-                arg: "updateAttributeById",
-                type: "Dataset",
-                root: true,
-                description: "The updated Dataset"
-            }
-        ],
-        description: "Update a single attribute of a dataset",
-        http: [
-            {
-                path: "/updateScientificMetadata",
-                verb: "put"
-            }
-        ]
-    });
 };

--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -477,7 +477,10 @@ module.exports = function(Dataset) {
                             $match: {
                                 $or: [
                                     {
-                                        $text: searchExpression(key, fields[key])
+                                        $text: searchExpression(
+                                            key,
+                                            fields[key]
+                                        )
                                     },
                                     {
                                         sourceFolder: {
@@ -667,7 +670,7 @@ module.exports = function(Dataset) {
                         });
                     }
                 } else {
-                    if (typeof fields[key] === "string") {
+                    if (typeof fields[key].constructor !== Object) {
                         let match = {};
                         match[key] = searchExpression(key, fields[key]);
                         pipeline.push({


### PR DESCRIPTION
## Description

Fixed broken fullquery filtering and removed obsolete method updateScientificMetadata

## Motivation 

Checking for string broke fullquery

## Changes:

* Changed fullquery type check to check that field is not an object instead of checking for a string
* Removed obsolete method updateScientificMetadata

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
