### PR TITLE
Extended printout for job related emails

### DIFF
--- a/common/models/job.json
+++ b/common/models/job.json
@@ -84,6 +84,10 @@
           "type": "object"
         },
         {
+          "arg": "includeFields",
+          "type": "object"
+        },
+        {
           "arg": "options",
           "type": "object",
           "http": "optionsFromRequest"


### PR DESCRIPTION
## Description
More information given to the user in auto generated job emails about the datasets being treated.

## Motivation 
Users were complaining to see only dataset IDs which means nothing to them

## Changes:
* Job.datasetDetails API endpoint was extended as well to cope with very large retrieve jobs.
* email printout
* 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
