### PR TITLE
Allow non ingestor users to create published data

### DIFF
--- a/common/models/published-data.json
+++ b/common/models/published-data.json
@@ -110,25 +110,57 @@
   },
   "validations": [],
   "relations": {},
-  "acls": [
-    {
-      "accessType": "*",
-      "principalType": "ROLE",
-      "principalId": "$everyone",
-      "permission": "DENY"
-    },
-    {
+    "acls": [
+      {
+        "accessType": "*",
+        "principalType": "ROLE",
+        "principalId": "$everyone",
+        "permission": "DENY"
+      },
+      {
+        "accessType": "*",
+        "principalType": "ROLE",
+        "principalId": "admin",
+        "permission": "ALLOW"
+      },
+      {
+        "principalType": "ROLE",
+        "principalId": "$authenticated",
+        "permission": "ALLOW",
+        "property": ["create","patchOrCreate","patchAttributes", "updateAll"]
+      },
+      {
       "accessType": "*",
       "principalType": "ROLE",
       "principalId": "ingestor",
       "permission": "ALLOW"
-    },
-    {
-      "accessType": "READ",
+  },
+  {
+      "accessType": "*",
       "principalType": "ROLE",
-      "principalId": "$everyone",
+      "principalId": "$authenticated",
       "permission": "ALLOW"
-    }
-  ],
+  },
+  {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$authenticated",
+      "permission": "DENY",
+      "property": ["reset", "destroyById", "deleteById"]
+  },
+  {
+      "principalType": "ROLE",
+      "principalId": "archivemanager",
+      "permission": "ALLOW",
+      "property": ["reset", "destroyById", "deleteById"]
+  },
+  {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "ingestor",
+      "permission": "DENY",
+      "property": ["patchAttributes", "updateAll"]
+  }
+],
   "methods": {}
 }


### PR DESCRIPTION
## Description
So far only the ingestor can create published data. Allow authenticated users to do this as well. Prevent deletion of entries however.

