### PR TITLE
Feature/persisted columns

### DIFF
--- a/common/models/logbook.js
+++ b/common/models/logbook.js
@@ -8,8 +8,6 @@ let logbookEnabled, scichatBaseUrl, scichatUser, scichatPass;
 
 checkConfigProperties();
 
-scichatBaseUrl = "localhost:3030/api";
-
 module.exports = function(Logbook) {
     /**
      * Find Logbook model instance

--- a/common/models/logbook.js
+++ b/common/models/logbook.js
@@ -8,6 +8,8 @@ let logbookEnabled, scichatBaseUrl, scichatUser, scichatPass;
 
 checkConfigProperties();
 
+scichatBaseUrl = "localhost:3030/api";
+
 module.exports = function(Logbook) {
     /**
      * Find Logbook model instance

--- a/common/models/user-setting.js
+++ b/common/models/user-setting.js
@@ -1,5 +1,5 @@
-'use strict';
+"use strict";
 
-module.exports = function(Usersetting) {
-
+module.exports = function(UserSetting) {
+    
 };

--- a/common/models/user-setting.json
+++ b/common/models/user-setting.json
@@ -1,14 +1,14 @@
 {
   "name": "UserSetting",
   "description": "User settings such as job count and dataset count",
-  "base": "Ownable",
+  "base": "PersistedModel",
   "idInjection": true,
   "options": {
     "validateUpsert": true
   },
   "properties": {
     "columns": {
-      "type": "object"
+      "type": ["object"]
     },
     "email": {
       "type": "string"
@@ -23,7 +23,13 @@
     }
   },
   "validations": [],
-  "relations": {},
+  "relations": {
+    "user": {
+      "type": "belongsTo",
+      "model": "User",
+      "foreignKey": ""
+    }
+  },
   "acls": [],
   "methods": {}
 }

--- a/common/models/user-setting.json
+++ b/common/models/user-setting.json
@@ -8,10 +8,9 @@
   },
   "properties": {
     "columns": {
-      "type": ["object"]
-    },
-    "email": {
-      "type": "string"
+      "type": [
+        "object"
+      ]
     },
     "datasetCount": {
       "type": "number",
@@ -30,6 +29,19 @@
       "foreignKey": ""
     }
   },
-  "acls": [],
+  "acls": [
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "DENY"
+    },
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW"
+    }
+  ],
   "methods": {}
 }

--- a/server/boot/0-script.js
+++ b/server/boot/0-script.js
@@ -235,4 +235,10 @@ module.exports = function(app) {
             verb: "get"
         }
     });
+
+    console.log("Adding relations for User");
+
+    const UserSetting = app.models.UserSetting;
+
+    User.hasOne(UserSetting, {foreignKey: "", as: "settings"});
 };

--- a/server/boot/0-script.js
+++ b/server/boot/0-script.js
@@ -1,4 +1,6 @@
 module.exports = function(app) {
+    const logger = require("../../common/logger");
+
     var dataSource = app.datasources.mongo;
     console.log(
         "Datasource host %s, database %s",
@@ -248,13 +250,15 @@ module.exports = function(app) {
         }
     });
 
-    console.log("Adding relations for User");
+    logger.logInfo("Adding relations to User", { relation: "UserSetting" });
 
     const UserSetting = app.models.UserSetting;
 
     User.hasOne(UserSetting, { foreignKey: "", as: "settings" });
 
-    console.log("Adding ACLS for User related models");
+    logger.logInfo("Adding ACLS for User related models", {
+        relation: "UserSetting"
+    });
 
     const userACLS = User.settings.acls;
 
@@ -287,12 +291,10 @@ module.exports = function(app) {
     User.afterRemote("findById", function(ctx, user, next) {
         user.settings((err, settings) => {
             if (err) {
-                console.error(err);
+                logger.logError(err.message);
             } else if (!settings) {
-                console.log("Adding default settings to user");
+                logger.logInfo("Adding default settings to user", { user });
                 user.settings.create({ columns: [] });
-            } else {
-                console.log("settings", settings);
             }
         });
         next();

--- a/server/boot/0-script.js
+++ b/server/boot/0-script.js
@@ -77,25 +77,32 @@ module.exports = function(app) {
                 } else {
                     console.log(err);
                 }
-        });
-        db.collection('Sample').createIndex({
-            "$**": "text"
-        }, function (err) {
-            if (!err) {
-                console.log("Text Index on sample created successfully")
-            } else {
-                console.log(err);
             }
-        });
-        db.collection('Proposal').createIndex({
-            "$**": "text"
-        }, function (err) {
-            if (!err) {
-                console.log("Text Index on proposal created successfully")
-            } else {
-                console.log(err);
+        );
+        db.collection("Sample").createIndex(
+            {
+                "$**": "text"
+            },
+            function(err) {
+                if (!err) {
+                    console.log("Text Index on sample created successfully");
+                } else {
+                    console.log(err);
+                }
             }
-        });
+        );
+        db.collection("Proposal").createIndex(
+            {
+                "$**": "text"
+            },
+            function(err) {
+                if (!err) {
+                    console.log("Text Index on proposal created successfully");
+                } else {
+                    console.log(err);
+                }
+            }
+        );
     });
 
     // add further information to options parameter
@@ -147,20 +154,25 @@ module.exports = function(app) {
                                 }
                                 const regex = "/" + u.profile.email + "/i";
                                 // get users share groups and add to the current groups context
-                                ShareGroup.find( {where: {members: {regexp: regex }}}, function(err, share) {
-                                    if (err) return next(err);
-                                    groups = [...groups, ...(share.map(({ id }) => { return String(id)}))];
-                                    ctx.args.options.currentGroups = groups;
-                                    // console.log("============ Phase:", ctx.args.options.currentGroups)
-                                    return next();
-                                });
-                            }
-                            else {
+                                ShareGroup.find(
+                                    { where: { members: { regexp: regex } } },
+                                    function(err, share) {
+                                        if (err) return next(err);
+                                        groups = [
+                                            ...groups,
+                                            ...share.map(({ id }) => {
+                                                return String(id);
+                                            })
+                                        ];
+                                        ctx.args.options.currentGroups = groups;
+                                        // console.log("============ Phase:", ctx.args.options.currentGroups)
+                                        return next();
+                                    }
+                                );
+                            } else {
                                 ctx.args.options.currentGroups = [];
                                 return next();
                             }
-                            
-                            
                         } else {
                             // authorizedRoles can not be used for this, since roles depend on the ACLs used in a collection,
                             // fetch roles via Rolemapping table instead
@@ -240,5 +252,49 @@ module.exports = function(app) {
 
     const UserSetting = app.models.UserSetting;
 
-    User.hasOne(UserSetting, {foreignKey: "", as: "settings"});
+    User.hasOne(UserSetting, { foreignKey: "", as: "settings" });
+
+    console.log("Adding ACLS for User related models");
+
+    const userACLS = User.settings.acls;
+
+    const userSettingsACLS = [
+        {
+            principalType: "ROLE",
+            principalId: "$owner",
+            permission: "ALLOW",
+            property: [
+                "__create__settings",
+                "__get__settings",
+                "__update__settings"
+            ]
+        },
+        {
+            principalType: "ROLE",
+            principalId: "admin",
+            permission: "ALLOW",
+            property: [
+                "__create__settings",
+                "__get__settings",
+                "__update__settings",
+                "__destroy__settings"
+            ]
+        }
+    ];
+
+    User.settings.acls = userACLS.concat(userSettingsACLS);
+
+    User.afterRemote("findById", function(ctx, user, next) {
+        user.settings((err, settings) => {
+            if (err) {
+                console.error(err);
+            } else if (!settings) {
+                console.log("Adding default settings to user");
+                user.settings.create({ columns: [] });
+            } else {
+                console.log("settings", settings);
+            }
+        });
+        next();
+    });
 };


### PR DESCRIPTION
## Description

Added relation between User and UserSetting models

## Motivation 

Part of issue #231 

## Changes:

* Changed UserSetting from "Ownable" to "PersistedModel".
* Changed UserSetting.columns type from `object` to `[object]`.
* Removed email property from UserSetting.
* Added ACLS to UserSetting model allowing only admin to create, get, update, and destroy directly.
* Added relation between User and UserSetting models.
* Added ACLS for relation. Owner has the right to create, get and update settings. Admin also has these rights + rights to destroy.
* Added automatic creation of a UserSetting collection if current user doesn't already have one.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
