### PR TITLE
Feature/logbook group access

### DIFF
--- a/common/models/logbook.js
+++ b/common/models/logbook.js
@@ -4,6 +4,7 @@ const app = require("../../server/server");
 const superagent = require("superagent");
 const rison = require("rison");
 const config = require("../../server/config.local");
+const logger = require("../logger");
 
 let logbookEnabled, scichatBaseUrl, scichatUser, scichatPass;
 
@@ -73,7 +74,9 @@ module.exports = function(Logbook) {
             );
             return;
         } catch (err) {
-            console.error(err);
+            logger.logError(err.message, {
+                location: "Logbook.afterRemote.findAll"
+            });
             return;
         }
     });
@@ -97,7 +100,10 @@ module.exports = function(Logbook) {
                 );
                 return fetchResponse.body;
             } catch (err) {
-                console.error(err);
+                logger.logError(err.message, {
+                    location: "Logbook.findByName",
+                    name
+                });
             }
         } else {
             return [];
@@ -134,7 +140,7 @@ module.exports = function(Logbook) {
                     .reverse();
                 return nonEmptyLogbooks.concat(emptyLogbooks);
             } catch (err) {
-                console.error(err);
+                logger.logError(err.message, { location: "Logbook.findAll" });
             }
         } else {
             return [];
@@ -171,7 +177,11 @@ module.exports = function(Logbook) {
                     return fetchResponse.body;
                 }
             } catch (err) {
-                console.error(err);
+                logger.logError(err.message, {
+                    location: "Logbook.filter",
+                    name,
+                    filter
+                });
             }
         } else {
             return [];
@@ -197,7 +207,7 @@ async function scichatLogin(username, password) {
             .send(userData);
         return loginResponse.body.id;
     } catch (err) {
-        console.error(err);
+        logger.logError(err.message, { username });
     }
 }
 

--- a/common/models/logbook.js
+++ b/common/models/logbook.js
@@ -11,74 +11,25 @@ let logbookEnabled, scichatBaseUrl, scichatUser, scichatPass;
 checkConfigProperties();
 
 module.exports = function(Logbook) {
+    Logbook.afterRemote("findByName", async function(ctx, logbook) {
+        const { userId } = ctx.req.accessToken;
+        const proposalIds = await getUserProposals(userId);
+        ctx.result = proposalIds.includes(logbook.name) ? logbook : null;
+        return;
+    });
+
     Logbook.afterRemote("findAll", async function(ctx, logbooks) {
         const { userId } = ctx.req.accessToken;
-        const User = app.models.User;
-        const UserIdentity = app.models.UserIdentity;
-        const ShareGroup = app.models.ShareGroup;
-        const RoleMapping = app.models.RoleMapping;
-        const Role = app.models.Role;
-        const Proposal = app.models.Proposal;
+        const proposalIds = await getUserProposals(userId);
+        ctx.result = logbooks.filter(({ name }) => proposalIds.includes(name));
+        return;
+    });
 
-        let options = {};
-
-        try {
-            const user = await User.findById(userId);
-            options.currentUser = user.username;
-            options.currentUserEmail = user.email;
-
-            const userIdentity = await UserIdentity.findOne({
-                where: { userId }
-            });
-            if (!!userIdentity) {
-                let groups = [];
-                if (userIdentity.profile) {
-                    options.currentUser = userIdentity.profile.username;
-                    options.currentUserEmail = userIdentity.profile.email;
-                    groups = userIdentity.profile.accessGroups;
-                    if (!groups) {
-                        groups = [];
-                    }
-                    const regex = new RegExp(userIdentity.profile.email, "i");
-
-                    const shareGroup = await ShareGroup.find({
-                        where: { members: { regexp: regex } }
-                    });
-                    groups = [
-                        ...groups,
-                        ...shareGroup.map(({ id }) => String(id))
-                    ];
-                    options.currentGroups = groups;
-                } else {
-                    options.currentGroups = groups;
-                }
-            } else {
-                const roleMapping = await RoleMapping.find(
-                    { where: { principalId: String(userId) } },
-                    options
-                );
-                const roleIdList = roleMapping.map(instance => instance.roleId);
-
-                const role = await Role.find({
-                    where: { id: { inq: roleIdList } }
-                });
-                const roleNameList = role.map(instance => instance.name);
-                roleNameList.push(user.username);
-                options.currentGroups = roleNameList;
-            }
-
-            const proposals = await Proposal.fullquery({}, {}, options);
-            const proposalIds = proposals.map(proposal => proposal.proposalId);
-            ctx.result = logbooks.filter(({ name }) =>
-                proposalIds.includes(name)
-            );
-            return;
-        } catch (err) {
-            logger.logError(err.message, {
-                location: "Logbook.afterRemote.findAll"
-            });
-            return;
-        }
+    Logbook.afterRemote("filter", async function(ctx, logbook) {
+        const { userId } = ctx.req.accessToken;
+        const proposalIds = await getUserProposals(userId);
+        ctx.result = proposalIds.includes(logbook.name) ? logbook : null;
+        return;
     });
 
     /**
@@ -208,6 +159,74 @@ async function scichatLogin(username, password) {
         return loginResponse.body.id;
     } catch (err) {
         logger.logError(err.message, { username });
+    }
+}
+
+/**
+ * Get ids of proposals that the user has permissions to view
+ * @param {string} userId Id of current user
+ * @returns {string[]} Array of proposalIds
+ */
+
+async function getUserProposals(userId) {
+    const User = app.models.User;
+    const UserIdentity = app.models.UserIdentity;
+    const ShareGroup = app.models.ShareGroup;
+    const RoleMapping = app.models.RoleMapping;
+    const Role = app.models.Role;
+    const Proposal = app.models.Proposal;
+
+    let options = {};
+
+    try {
+        const user = await User.findById(userId);
+        options.currentUser = user.username;
+        options.currentUserEmail = user.email;
+
+        const userIdentity = await UserIdentity.findOne({
+            where: { userId }
+        });
+        if (!!userIdentity) {
+            let groups = [];
+            if (userIdentity.profile) {
+                options.currentUser = userIdentity.profile.username;
+                options.currentUserEmail = userIdentity.profile.email;
+                groups = userIdentity.profile.accessGroups;
+                if (!groups) {
+                    groups = [];
+                }
+                const regex = new RegExp(userIdentity.profile.email, "i");
+
+                const shareGroup = await ShareGroup.find({
+                    where: { members: { regexp: regex } }
+                });
+                groups = [...groups, ...shareGroup.map(({ id }) => String(id))];
+                options.currentGroups = groups;
+            } else {
+                options.currentGroups = groups;
+            }
+        } else {
+            const roleMapping = await RoleMapping.find(
+                { where: { principalId: String(userId) } },
+                options
+            );
+            const roleIdList = roleMapping.map(instance => instance.roleId);
+
+            const role = await Role.find({
+                where: { id: { inq: roleIdList } }
+            });
+            const roleNameList = role.map(instance => instance.name);
+            roleNameList.push(user.username);
+            options.currentGroups = roleNameList;
+        }
+
+        const proposals = await Proposal.fullquery({}, {}, options);
+        return proposals.map(proposal => proposal.proposalId);
+    } catch (err) {
+        logger.logError(err.message, {
+            location: "Logbook.getUserProposals",
+            userId
+        });
     }
 }
 

--- a/common/models/logbook.json
+++ b/common/models/logbook.json
@@ -25,36 +25,14 @@
     {
       "accessType": "*",
       "principalType": "ROLE",
-      "principalId": "ingestor",
-      "permission": "ALLOW"
+      "principalId": "$unauthenticated",
+      "permission": "DENY"
     },
     {
       "accessType": "*",
       "principalType": "ROLE",
       "principalId": "$authenticated",
       "permission": "ALLOW"
-    },
-    {
-      "accessType": "READ",
-      "principalType": "ROLE",
-      "principalId": "proposalingestor",
-      "permission": "DENY"
-    },
-    {
-      "principalType": "ROLE",
-      "principalId": "archivemanager",
-      "permission": "ALLOW",
-      "property": "reset"
-    },
-    {
-      "principalType": "ROLE",
-      "principalId": "$everyone",
-      "permission": "ALLOW",
-      "property": [
-        "findByName",
-        "findAll",
-        "filter"
-      ]
     }
   ],
   "methods": {


### PR DESCRIPTION
## Description

Added group permissions to logbook endpoint by adding remote hooks that filters logbooks based on which proposals user has access to.

## Motivation 

A user, I should only be allowed to view logbooks for the proposals that I have access to.

## Changes:

* Added method `getUserProposals` for getting proposals that the user has access to.
* Added afterRemote hooks to logbook model that filters results based on the proposalIds returned by `getUserProposals`.
* Replaced `console.log/error` with logger.
* Updated permissions for logbook model (deny unauthenticated users, allow all authenticated users)

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
