### PR TITLE
Feature/attachment extends ownable

### DIFF
--- a/common/models/attachment.json
+++ b/common/models/attachment.json
@@ -17,10 +17,6 @@
       "type": "string",
       "description": "Attachment caption to show in catanie",
       "default": ""
-    },
-    "creationTime": {
-      "type": "date",
-      "description": "Time when attachment is created. Format according to chapter 5.6 internet date/time format in RFC 3339"
     }
   },
   "validations": [],

--- a/common/models/attachment.json
+++ b/common/models/attachment.json
@@ -1,7 +1,7 @@
 {
   "name": "Attachment",
   "description": "Small less than 16 MB attachments, envisaged for png/jpeg previews",
-  "base": "PersistedModel",
+  "base": "Ownable",
   "idInjection": true,
   "options": {
     "validateUpsert": true

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -119,8 +119,8 @@ describe("Simple Dataset tests", () => {
                 res.body.should.have.property("thumbnail").and.equal(testAttachment.thumbnail);
                 res.body.should.have.property("caption").and.equal(testAttachment.caption);
                 res.body.should.have.property("ownerGroup").and.equal(testAttachment.ownerGroup);
-                res.body.should.have.property("accessGroup").and.equal(testAttachment.accessGroups);
-                res.body.should.have.property("createdBy").and.equal(testAttachment.createdBy);
+                res.body.should.have.property("accessGroups");
+                res.body.should.have.property("createdBy");
                 res.body.should.have.property("updatedBy").and.be.string;
                 res.body.should.have.property("createdAt");
                 res.body.should.have.property("id").and.be.string;

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -96,7 +96,6 @@ describe("Simple Dataset tests", () => {
             "thumbnail": "data/abc123",
             "caption": "Some caption",
             "datasetId": defaultPid,
-            "creationTime": new Date(),
             "ownerGroup": "ess",
             "accessGroups": ["loki", "odin"],
             "createdBy": "Bertram Astor",

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -95,8 +95,14 @@ describe("Simple Dataset tests", () => {
         const testAttachment = {
             "thumbnail": "data/abc123",
             "caption": "Some caption",
+            "datasetId": defaultPid,
             "creationTime": new Date(),
-            "datasetId": defaultPid
+            "ownerGroup": "ess",
+            "accessGroups": ["loki", "odin"],
+            "createdBy": "Bertram Astor",
+            "updatedBy": "anonymous",
+            "createdAt": new Date(),
+            "updatedAt": new Date()
         };
         request(app)
             .post(

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -118,7 +118,11 @@ describe("Simple Dataset tests", () => {
                 if (err) return done(err);
                 res.body.should.have.property("thumbnail").and.equal(testAttachment.thumbnail);
                 res.body.should.have.property("caption").and.equal(testAttachment.caption);
-                res.body.should.have.property("creationTime");
+                res.body.should.have.property("ownerGroup").and.equal(testAttachment.ownerGroup);
+                res.body.should.have.property("accessGroup").and.equal(testAttachment.accessGroups);
+                res.body.should.have.property("createdBy").and.equal(testAttachment.createdBy);
+                res.body.should.have.property("updatedBy").and.be.string;
+                res.body.should.have.property("createdAt");
                 res.body.should.have.property("id").and.be.string;
                 res.body.should.have.property("datasetId").and.equal(testAttachment.datasetId);
                 attachmentId = encodeURIComponent(res.body["id"]);

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -112,8 +112,13 @@ describe('Simple Proposal tests', () => {
         const testAttachment = {
             "thumbnail": "data/abc123",
             "caption": "Some caption",
-            "creationTime": new Date(),
-            "proposalId": defaultProposalId
+            "proposalId": defaultProposalId,
+            "ownerGroup": "ess",
+            "accessGroups": ["loki", "odin"],
+            "createdBy": "Bertram Astor",
+            "updatedBy": "anonymous",
+            "createdAt": new Date(),
+            "updatedAt": new Date()
         };
         request(app)
             .post(
@@ -130,7 +135,11 @@ describe('Simple Proposal tests', () => {
                 if (err) return done(err);
                 res.body.should.have.property("thumbnail").and.equal(testAttachment.thumbnail);
                 res.body.should.have.property("caption").and.equal(testAttachment.caption);
-                res.body.should.have.property("creationTime");
+                res.body.should.have.property("ownerGroup").and.equal(testAttachment.ownerGroup);
+                res.body.should.have.property("accessGroups");
+                res.body.should.have.property("createdBy");
+                res.body.should.have.property("updatedBy").and.be.string;
+                res.body.should.have.property("createdAt");
                 res.body.should.have.property("id").and.be.string;
                 res.body.should.have.property("proposalId").and.equal(testAttachment.proposalId);
                 attachmentId = encodeURIComponent(res.body["id"]);

--- a/test/Sample.js
+++ b/test/Sample.js
@@ -81,8 +81,13 @@ describe('Simple Sample tests', () => {
         const testAttachment = {
             "thumbnail": "data/abc123",
             "caption": "Some caption",
-            "creationTime": new Date(),
-            "sampleId": defaultSampleId
+            "sampleId": defaultSampleId,
+            "ownerGroup": "ess",
+            "accessGroups": ["loki", "odin"],
+            "createdBy": "Bertram Astor",
+            "updatedBy": "anonymous",
+            "createdAt": new Date(),
+            "updatedAt": new Date()
         };
         request(app)
             .post(
@@ -99,7 +104,11 @@ describe('Simple Sample tests', () => {
                 if (err) return done(err);
                 res.body.should.have.property("thumbnail").and.equal(testAttachment.thumbnail);
                 res.body.should.have.property("caption").and.equal(testAttachment.caption);
-                res.body.should.have.property("creationTime");
+                res.body.should.have.property("ownerGroup").and.equal(testAttachment.ownerGroup);
+                res.body.should.have.property("accessGroups");
+                res.body.should.have.property("createdBy");
+                res.body.should.have.property("updatedBy").and.be.string;
+                res.body.should.have.property("createdAt");
                 res.body.should.have.property("id").and.be.string;
                 res.body.should.have.property("sampleId").and.equal(testAttachment.sampleId);
                 attachmentId = encodeURIComponent(res.body["id"]);


### PR DESCRIPTION
## Description

Changed Attachment base model from `PersistedModel` to `Ownable`.

Related to catanie pr [#638](https://github.com/SciCatProject/catanie/pull/638)

## Motivation 

As a user I should only be allowed to access attachments that belongs to my access groups.

## Changes:

* Changed Attachment base model from `PersistedModel` to `Ownable`.
* Removed property `creationTime` from Attachment model, since Ownable already has property `createdAt`.

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
