### PR TITLE
Limit the number of datasets fetched for metadata key retrieval

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -937,30 +937,34 @@ module.exports = function(Dataset) {
         });
     };
 
-    Dataset.metadataKeys = async function(fields, lm,  options) {
+    Dataset.metadataKeys = async function(fields, limits,  options) {
         try {
             const blacklist = [new RegExp(".*_date"), new RegExp("runNumber")];
             const returnLimit = config.metadataKeysReturnLimit;
             const { metadataKey } = fields;
 
             // ensure that no more than MAXLIMIT datasets are read for metadata key extraction
-            let MAXLIMIT=100
-            if( config.metadataDatasetsReturnLimit ){
-                MAXLIMIT = config.metadataDatasetsReturnLimit
-            } 
-            let limits
-            if (lm) {
-                limits=JSON.parse(JSON.stringify(lm))
-            } else {
-                limits={}
-            }
-            if (limits.limit){
-                if (limits.limit > MAXLIMIT){
-                   limits.limit=MAXLIMIT
+            let MAXLIMIT;
+            if(config.metadataDatasetsReturnLimit) {
+                MAXLIMIT = config.metadataDatasetsReturnLimit;
+                
+                let lm;
+               
+                if (limits) {
+                    lm = JSON.parse(JSON.stringify(limits));
+                } else {
+                    lm = {};
                 }
-            } else {
-                limits.limit=MAXLIMIT
-            }
+                
+                if (lm.limit) {
+                    if (lm.limit > MAXLIMIT) {
+                        lm.limit = MAXLIMIT;
+                    }
+                } else {
+                    lm.limit = MAXLIMIT;
+                }
+                limits = lm;
+            } 
 
             logger.logInfo("Fetching metadataKeys", {
                 fields,

--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -937,7 +937,7 @@ module.exports = function(Dataset) {
         });
     };
 
-    Dataset.metadataKeys = async function(fields, limits,  options) {
+    Dataset.metadataKeys = async function(fields, limits, options) {
         try {
             const blacklist = [new RegExp(".*_date"), new RegExp("runNumber")];
             const returnLimit = config.metadataKeysReturnLimit;

--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -937,11 +937,30 @@ module.exports = function(Dataset) {
         });
     };
 
-    Dataset.metadataKeys = async function(fields, limits, options) {
+    Dataset.metadataKeys = async function(fields, lm,  options) {
         try {
             const blacklist = [new RegExp(".*_date"), new RegExp("runNumber")];
             const returnLimit = config.metadataKeysReturnLimit;
             const { metadataKey } = fields;
+
+            // ensure that no more than MAXLIMIT datasets are read for metadata key extraction
+            let MAXLIMIT=100
+            if( config.metadataDatasetsReturnLimit ){
+                MAXLIMIT = config.metadataDatasetsReturnLimit
+            } 
+            let limits
+            if (lm) {
+                limits=JSON.parse(JSON.stringify(lm))
+            } else {
+                limits={}
+            }
+            if (limits.limit){
+                if (limits.limit > MAXLIMIT){
+                   limits.limit=MAXLIMIT
+                }
+            } else {
+                limits.limit=MAXLIMIT
+            }
 
             logger.logInfo("Fetching metadataKeys", {
                 fields,


### PR DESCRIPTION
## Description
Retrieving too many datasets for defining the possible keys slows down the program, especially for users having access to many datasets. Therefore one can now limit the numbers of dataset which can be fetched as maximum. Default limit is 100 datasets.

## Motivation 
Keep browser responsive for users with large number of datasets

## Extra Information/Screenshots
The parameter   metadataDatasetsReturnLimit:<.. put limit here...>, can be set inside config.local.js at server startup