### PR TITLE
Feature/filenamesearchsupport

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -544,7 +544,7 @@ module.exports = function(Dataset) {
             const { metadataKey, ...theRest } = fields;
             fields = { ...theRest };
         }
-        if (fields.isPublished === false) {
+        if (!('isPublished' in fields) || !fields.isPublished) {
             const { isPublished, ...theRest } = fields;
             return { ...theRest, userGroups: options.currentGroups };
         }

--- a/common/models/orig-datablock.js
+++ b/common/models/orig-datablock.js
@@ -93,13 +93,11 @@ module.exports = function (Origdatablock) {
                 ...theRest
             };
         }
-        console.log("Before adding usergroup:", fields)
         if (!('isPublished' in fields) || !fields.isPublished) {
             const {
                 isPublished,
                 ...theRest
             } = fields;
-            console.log("Adding usergroup")
             return {
                 ...theRest,
                 userGroups: options.currentGroups

--- a/common/models/orig-datablock.js
+++ b/common/models/orig-datablock.js
@@ -208,7 +208,15 @@ module.exports = function (Origdatablock) {
                 pipeline.push({
                     $limit: Number(limits.limit) < 1 ? 1 : Number(limits.limit)
                 });
+            } else {
+                pipeline.push({
+                    $limit: 100
+                });
             }
+        } else {
+            pipeline.push({
+                $limit: 100
+            });
         }
 
         // group results by dataset
@@ -220,7 +228,7 @@ module.exports = function (Origdatablock) {
                 }
             }
         })
-        // console.log("Resulting aggregate query in findFilesByName method:", JSON.stringify(pipeline, null, 3));
+        console.log("Resulting aggregate query in findFilesByName method:", JSON.stringify(pipeline, null, 3));
 
         Origdatablock.getDataSource().connector.connect(function (err, db) {
             var collection = db.collection("OrigDatablock");

--- a/common/models/orig-datablock.js
+++ b/common/models/orig-datablock.js
@@ -115,7 +115,6 @@ module.exports = function (Origdatablock) {
     */
 
     Origdatablock.findFilesByName = function (fields, limits, options, cb) {
-        // keep the full aggregation pipeline definition
         let pipeline = [];
         fields = setFields(fields, options);
         // construct match conditions from fields value
@@ -128,10 +127,17 @@ module.exports = function (Origdatablock) {
                         }
                     });
                 } else if (key === "filenameExp") {
+                    // for simplicity always do a case insensitive search
+                    // use combined $text and filepath search for best performance
+                    // also in case of arbitrary substring search
                     pipeline.push({
                         $match: {
+                            $text: {
+                                $search: fields[key]
+                            },
                             "dataFileList.path": {
-                                "$regex": fields[key]
+                                $regex: fields[key],
+                                $options: 'i'
                             }
                         }
                     });

--- a/common/models/orig-datablock.js
+++ b/common/models/orig-datablock.js
@@ -119,16 +119,10 @@ module.exports = function (Origdatablock) {
     Origdatablock.findFilesByName = function (fields, limits, options, cb) {
         // keep the full aggregation pipeline definition
         let pipeline = [];
-        console.log("Input fields,options", fields, options)
         fields = setFields(fields, options);
-        console.log("After setFields:", fields)
-        // console.log("Inside fullquery:options",options)
-        // console.log("++++++++++++ fullquery: after filling fields with usergroup:",fields)
-        // let matchJoin = {}
         // construct match conditions from fields value
         Object.keys(fields).map(function (key) {
             if (fields[key] && fields[key] !== "null") {
-                // mode is not a field in dataset, just an object for containing a match clause
                 if (key === "datasetId") {
                     pipeline.push({
                         $match: {
@@ -180,7 +174,6 @@ module.exports = function (Origdatablock) {
             "$unwind": "$dataFileList"
         })
         if ('filenameExp' in fields && fields['filenameExp'] !== "") {
-            console.log("filename expression:", fields['filenameExp'])
             pipeline.push({
                 "$match": {
                     "dataFileList.path": {
@@ -229,7 +222,7 @@ module.exports = function (Origdatablock) {
                 }
             }
         })
-        console.log("Resulting aggregate query in findFilesByName method:", JSON.stringify(pipeline, null, 3));
+        // console.log("Resulting aggregate query in findFilesByName method:", JSON.stringify(pipeline, null, 3));
 
         Origdatablock.getDataSource().connector.connect(function (err, db) {
             var collection = db.collection("OrigDatablock");

--- a/common/models/orig-datablock.js
+++ b/common/models/orig-datablock.js
@@ -1,25 +1,25 @@
 'use strict';
 var utils = require('./utils');
+var own = require("./ownable.json");
 
-
-module.exports = function(Origdatablock) {
+module.exports = function (Origdatablock) {
     var app = require('../../server/server');
 
     // put
-    Origdatablock.beforeRemote('replaceOrCreate', function(ctx, instance, next) {
+    Origdatablock.beforeRemote('replaceOrCreate', function (ctx, instance, next) {
         // handle embedded datafile documents
         utils.updateAllTimesToUTC(["time"], ctx.args.data.dataFileList)
         next();
     });
 
     //patch
-    Origdatablock.beforeRemote('patchOrCreate', function(ctx, instance, next) {
+    Origdatablock.beforeRemote('patchOrCreate', function (ctx, instance, next) {
         utils.updateAllTimesToUTC(["time"], ctx.args.data.dataFileList)
         next();
     });
 
     //post
-    Origdatablock.beforeRemote('create', function(ctx, unused, next) {
+    Origdatablock.beforeRemote('create', function (ctx, unused, next) {
         utils.updateAllTimesToUTC(["time"], ctx.args.data.dataFileList)
         next();
     });
@@ -39,9 +39,9 @@ module.exports = function(Origdatablock) {
         utils.transferSizeToDataset(OrigDatablock, 'size', ctx, next)
     })
 
-    Origdatablock.isValid = function(instance, next) {
+    Origdatablock.isValid = function (instance, next) {
         var ds = new Origdatablock(instance)
-        ds.isValid(function(valid) {
+        ds.isValid(function (valid) {
             if (!valid) {
                 next(null, {
                     'errors': ds.errors,
@@ -54,4 +54,206 @@ module.exports = function(Origdatablock) {
             }
         });
     }
+
+    function searchExpression(key, value) {
+        let type = "string";
+        if (key in own.properties) {
+            type = own.properties[key].type;
+        }
+        if (type === "string") {
+            if (value.constructor === Array) {
+                if (value.length == 1) {
+                    return value[0];
+                } else {
+                    return {
+                        $in: value
+                    };
+                }
+            } else {
+                return value;
+            }
+        } else if (type.constructor === Array) {
+            return {
+                $in: value
+            };
+        }
+    }
+
+
+    function setFields(fields, options) {
+        if (fields === undefined) {
+            return {};
+        }
+        if (fields.metadataKey) {
+            const {
+                metadataKey,
+                ...theRest
+            } = fields;
+            fields = {
+                ...theRest
+            };
+        }
+        console.log("Before adding usergroup:", fields)
+        if (!('isPublished' in fields) || !fields.isPublished) {
+            const {
+                isPublished,
+                ...theRest
+            } = fields;
+            console.log("Adding usergroup")
+            return {
+                ...theRest,
+                userGroups: options.currentGroups
+            };
+        }
+        return fields;
+    }
+
+    /* returns filtered set of file objects. Options:
+       filter condition consists of fields
+       - ownerGroup (automatically applied on server side)
+       - datasetId (optional)
+       - filenameExp regexp expression (optional)
+     - paging of results
+    */
+
+    Origdatablock.findFilesByName = function (fields, limits, options, cb) {
+        // keep the full aggregation pipeline definition
+        let pipeline = [];
+        console.log("Input fields,options", fields, options)
+        fields = setFields(fields, options);
+        console.log("After setFields:", fields)
+        // console.log("Inside fullquery:options",options)
+        // console.log("++++++++++++ fullquery: after filling fields with usergroup:",fields)
+        // let matchJoin = {}
+        // construct match conditions from fields value
+        Object.keys(fields).map(function (key) {
+            if (fields[key] && fields[key] !== "null") {
+                // mode is not a field in dataset, just an object for containing a match clause
+                if (key === "datasetId") {
+                    pipeline.push({
+                        $match: {
+                            "datasetId": fields[key]
+                        }
+                    });
+                } else if (key === "filenameExp") {
+                    pipeline.push({
+                        $match: {
+                            "dataFileList.path": {
+                                "$regex": fields[key]
+                            }
+                        }
+                    });
+                } else if (key === "userGroups") {
+                    if (fields["userGroups"].indexOf("globalaccess") < 0) {
+                        pipeline.push({
+                            $match: {
+                                $or: [{
+                                        ownerGroup: searchExpression(
+                                            "ownerGroup",
+                                            fields["userGroups"]
+                                        )
+                                    },
+                                    {
+                                        accessGroups: searchExpression(
+                                            "accessGroups",
+                                            fields["userGroups"]
+                                        )
+                                    }
+                                ]
+                            }
+                        });
+                    }
+                }
+            }
+        });
+
+        // reformat answer
+
+        pipeline.push({
+            "$project": {
+                "dataFileList": 1,
+                "datasetId": 1,
+                "_id": 0
+            }
+        })
+        pipeline.push({
+            "$unwind": "$dataFileList"
+        })
+        if ('filenameExp' in fields && fields['filenameExp'] !== "") {
+            console.log("filename expression:", fields['filenameExp'])
+            pipeline.push({
+                "$match": {
+                    "dataFileList.path": {
+                        "$regex": fields["filenameExp"]
+                    }
+                }
+            })
+        }
+
+        // }
+        // final paging section ===========================================================
+        if (limits) {
+            if ("order" in limits) {
+                // input format: "creationTime:desc,creationLocation:asc"
+                const sortExpr = {};
+                const sortFields = limits.order.split(",");
+                sortFields.map(function (sortField) {
+                    const parts = sortField.split(":");
+                    const dir = parts[1] == "desc" ? -1 : 1;
+                    sortExpr[parts[0]] = dir;
+                });
+                pipeline.push({
+                    $sort: sortExpr
+                    // e.g. { $sort : { creationLocation : -1, creationLoation: 1 } }
+                });
+            }
+
+            if ("skip" in limits) {
+                pipeline.push({
+                    $skip: Number(limits.skip) < 1 ? 0 : Number(limits.skip)
+                });
+            }
+            if ("limit" in limits) {
+                pipeline.push({
+                    $limit: Number(limits.limit) < 1 ? 1 : Number(limits.limit)
+                });
+            }
+        }
+
+        // group results by dataset
+        pipeline.push({
+            "$group": {
+                "_id": "$datasetId",
+                "dataFileList": {
+                    "$push": "$dataFileList"
+                }
+            }
+        })
+        console.log("Resulting aggregate query in findFilesByName method:", JSON.stringify(pipeline, null, 3));
+
+        Origdatablock.getDataSource().connector.connect(function (err, db) {
+            var collection = db.collection("OrigDatablock");
+            var res = collection.aggregate(pipeline, {
+                allowDiskUse: true
+            }, function (err, cursor) {
+                cursor.toArray(function (err, res) {
+                    if (err) {
+                        console.log("findFilesByName err handling:", err);
+                    }
+                    // TODO restructure result
+                    res.map(ds => {
+                        Object.defineProperty(
+                            ds,
+                            "pid",
+                            Object.getOwnPropertyDescriptor(ds, "_id")
+                        );
+                        delete ds["_id"];
+                    });
+                    // console.log("Results:",JSON.stringify(res, null, 3));
+                    cb(err, res);
+                });
+            });
+        });
+    };
+
 }

--- a/common/models/orig-datablock.json
+++ b/common/models/orig-datablock.json
@@ -9,6 +9,11 @@
             "keys": {
                 "datasetId": 1
             }
+        },
+        "filename_index": {
+            "keys": {
+                "dataFileList.path": 1
+            }
         }
     },
     "options": {

--- a/common/models/orig-datablock.json
+++ b/common/models/orig-datablock.json
@@ -1,73 +1,100 @@
 {
-  "name": "OrigDatablock",
-  "description": "Container list all files and their attributes which make up a dataset. Usually Filled at the time the datasets metadata is created in the data catalog. Can be used by subsequent archiving processes to create the archived datasets.",
-  "base": "Ownable",
-  "strict": true,
-  "idInjection": true,
-  "indexes": {
-    "datasetId_index": {
-      "keys": {
-        "datasetId": 1
-      }
+    "name": "OrigDatablock",
+    "description": "Container list all files and their attributes which make up a dataset. Usually Filled at the time the datasets metadata is created in the data catalog. Can be used by subsequent archiving processes to create the archived datasets.",
+    "base": "Ownable",
+    "strict": true,
+    "idInjection": true,
+    "indexes": {
+        "datasetId_index": {
+            "keys": {
+                "datasetId": 1
+            }
+        }
+    },
+    "options": {
+        "validateUpsert": true
+    },
+    "properties": {
+        "id": {
+            "type": "string",
+            "required": true,
+            "description": "Automatically created ID"
+        },
+        "size": {
+            "type": "number",
+            "required": true,
+            "index": true,
+            "description": "Total size in bytes of all files contained in the dataFileList"
+        },
+        "dataFileList": {
+            "type": [
+                "Datafile"
+            ],
+            "required": true,
+            "description": "List of files contained in the linked dataset. Files can be regular files, folders and softlinks. All file paths are relative paths with respect to the sourceFolder location of the linked dataset."
+        }
+    },
+    "validations": [],
+    "relations": {
+        "dataset": {
+            "type": "belongsTo",
+            "model": "Dataset",
+            "foreignKey": "",
+            "required": true
+        }
+    },
+    "acls": [{
+            "accessType": "*",
+            "principalType": "ROLE",
+            "principalId": "ingestor",
+            "permission": "ALLOW"
+        },
+        {
+            "principalType": "ROLE",
+            "principalId": "ingestor",
+            "permission": "DENY",
+            "property": ["reset", "destroyById", "deleteById"]
+        },
+        {
+            "accessType": "WRITE",
+            "principalType": "ROLE",
+            "principalId": "proposalingestor",
+            "permission": "DENY"
+        },
+        {
+            "principalType": "ROLE",
+            "principalId": "archivemanager",
+            "permission": "ALLOW",
+            "property": ["reset", "destroyById", "deleteById"]
+        }
+    ],
+    "methods": {
+        "findFilesByName": {
+            "accepts": [{
+                    "arg": "fields",
+                    "type": "object",
+                    "description": "Define datasetId field to select a dataset and/or the filenameExp field to define a search regexp for file names."
+                },
+                {
+                    "arg": "limits",
+                    "type": "object",
+                    "description": "Define further query parameters like skip, limit, order"
+                },
+                {
+                    "arg": "options",
+                    "type": "object",
+                    "http": "optionsFromRequest"
+                }
+            ],
+            "returns": {
+                "root": true
+            },
+            "description": "Returns matching file objects in dataFileList grouped by dataset pid",
+            "http": {
+                "path": "/findFilesByName",
+                "verb": "get"
+            }
+        }
+
     }
-  },
-  "options": {
-    "validateUpsert": true
-  },
-  "properties": {
-    "id": {
-      "type": "string",
-      "required": true,
-      "description": "Automatically created ID"
-    },
-    "size": {
-      "type": "number",
-      "required": true,
-      "index": true,
-      "description": "Total size in bytes of all files contained in the dataFileList"
-    },
-    "dataFileList": {
-      "type": [
-        "Datafile"
-      ],
-      "required": true,
-      "description": "List of files contained in the linked dataset. Files can be regular files, folders and softlinks. All file paths are relative paths with respect to the sourceFolder location of the linked dataset."
-    }
-  },
-  "validations": [],
-  "relations": {
-    "dataset": {
-      "type": "belongsTo",
-      "model": "Dataset",
-      "foreignKey": "",
-      "required": true
-    }
-  },
-  "acls": [
-    {
-      "accessType": "*",
-      "principalType": "ROLE",
-      "principalId": "ingestor",
-      "permission": "ALLOW"
-    },
-    {
-      "principalType": "ROLE",
-      "principalId": "ingestor",
-      "permission": "DENY",
-      "property": ["reset", "destroyById", "deleteById"]
-    },
-    {
-      "accessType": "WRITE",
-      "principalType": "ROLE",
-      "principalId": "proposalingestor",
-      "permission": "DENY"
-    },
-    {
-      "principalType": "ROLE",
-      "principalId": "archivemanager",
-      "permission": "ALLOW",
-      "property": ["reset", "destroyById", "deleteById"]
-  }
-  ],
-  "methods": {}
 }

--- a/common/models/ownable.json
+++ b/common/models/ownable.json
@@ -27,10 +27,12 @@
       "type": [
         "string"
       ],
+      "index": true,
       "description": "Optional additional groups which have read access to the data. Users which are member in one of the groups listed here are allowed to access this data. The special group 'public' makes data available to all users"
     },
     "createdBy": {
       "type": "string",
+      "index": true,
       "description": "Functional or user account name who created this instance"
     },
     "updatedBy": {

--- a/common/models/published-data.json
+++ b/common/models/published-data.json
@@ -108,6 +108,10 @@
             "type": ["string"],
             "description": "List of URLs pointing to related publications like DOI URLS of journal articles"
         },
+        "downloadLink": {
+            "type": "string",
+            "description": "URL pointing to page from which data can be downloaded"
+        },
         "createdBy": {
             "type": "string",
             "description": "Functional or user account name who created this instance"

--- a/server/boot/0-script.js
+++ b/server/boot/0-script.js
@@ -69,42 +69,23 @@ module.exports = function(app) {
             );
         });
 
-        db.collection("Dataset").createIndex(
-            {
-                "$**": "text"
-            },
-            function(err) {
-                if (!err) {
-                    console.log("Text Index on dataset created successfully");
-                } else {
-                    console.log(err);
+        var textSearchCollections = [
+            "Dataset", "Sample", "Proposal", "OrigDatablock"
+        ]
+        textSearchCollections.forEach(function(coll) {
+            db.collection(coll).createIndex(
+                {
+                    "$**": "text"
+                },
+                function(err) {
+                    if (!err) {
+                        console.log("Text Index on " + coll + " created successfully");
+                    } else {
+                        console.log(err);
+                    }
                 }
-            }
-        );
-        db.collection("Sample").createIndex(
-            {
-                "$**": "text"
-            },
-            function(err) {
-                if (!err) {
-                    console.log("Text Index on sample created successfully");
-                } else {
-                    console.log(err);
-                }
-            }
-        );
-        db.collection("Proposal").createIndex(
-            {
-                "$**": "text"
-            },
-            function(err) {
-                if (!err) {
-                    console.log("Text Index on proposal created successfully");
-                } else {
-                    console.log(err);
-                }
-            }
-        );
+            );
+        })
     });
 
     // add further information to options parameter


### PR DESCRIPTION
## Description
Allow for efficient search on filenames. Return information about filenames both for a single dataset or across datasets. The functionality is implemented as an additional API endpoint on the OrigDatablock model

## Motivation 
Sometimes people want to find datasets based on filenames within the dataset. Also filtering by filename in a datasets detail view is often useful. Therefore the search must be efficient also for arbitrary substring searches in filenames

## Comment
Needs several new indices, being auto created at next catamel start

## Fixes:  #278 
