### PR TITLE
small changes in published-data.js

### DIFF
--- a/common/models/published-data.js
+++ b/common/models/published-data.js
@@ -16,10 +16,7 @@ function formRegistrationXML(publishedData) {
         resourceType,
         creator,
     } = publishedData;
-    const doi =
-        config.doiPrefix +
-        "/" +
-        publishedData["doi"].replace(config.pidPrefix, "");
+    const doi = publishedData["doi"];
     const uniqueCreator = creator.filter(
         (author, i) => creator.indexOf(author) === i
     );
@@ -201,8 +198,8 @@ module.exports = function (PublishedData) {
             });
 
             const fullDoi = pub.doi;
-            const registerMetadataUri = `https://mds.datacite.org/metadata/${fullDoi}`;
-            const registerDoiUri = `https://mds.datacite.org/doi/${fullDoi}`;
+            const registerMetadataUri = `${config.registerMetadataUri}/${fullDoi}`;
+            const registerDoiUri = `${config.registerDoiUri}/${fullDoi}`;
             const OAIServerUri = config.oaiProviderRoute;
 
             let doiProviderCredentials = {
@@ -211,11 +208,6 @@ module.exports = function (PublishedData) {
             };
             if (fs.existsSync(path)) {
                 doiProviderCredentials = JSON.parse(fs.readFileSync(path));
-            } else {
-                doiProviderCredentials = {
-                    username: "removed",
-                    password: "removed",
-                };
             }
             const registerDataciteMetadataOptions = {
                 method: "PUT",

--- a/server/config.local.js-sample
+++ b/server/config.local.js-sample
@@ -10,6 +10,8 @@ module.exports = {
     site: 'YOUR-SITE',
     facilities: ["Facility1", "Facility2"],
     metadataKeysReturnLimit: 100,
+    registerMetadataUri : `https://mds.test.datacite.org/metadata`,
+    registerDoiUri : `https://mds.test.datacite.org/doi`,
     grayLog: {
       enabled: false,
       host: "my.graylog.host",

--- a/server/config.local.js-sample
+++ b/server/config.local.js-sample
@@ -10,8 +10,8 @@ module.exports = {
     site: 'YOUR-SITE',
     facilities: ["Facility1", "Facility2"],
     metadataKeysReturnLimit: 100,
-    registerMetadataUri : `https://mds.test.datacite.org/metadata`,
-    registerDoiUri : `https://mds.test.datacite.org/doi`,
+    registerMetadataUri : "https://mds.test.datacite.org/metadata",
+    registerDoiUri : "https://mds.test.datacite.org/doi",
     grayLog: {
       enabled: false,
       host: "my.graylog.host",


### PR DESCRIPTION
## Description
Some small changes in published-data.js and move links for `registerMetadataUri` & `registerDoiUri` to config.local.js
## Motivation 
The function `formRegistrationXML` in published-data.js returns DOI with double prefix e.g `doiPrefix/doiPrefix/55c0ca48-5fa3-4c2f-927f-f8611b0661fb`
However the metadata showed in https://doi.datacite.org is still correct but I think we still need to remove the code to avoid confusion.

I suggest to move the links to config to makes it easier to configure development vs production site. We have DOI test repo at DataCite Fabrica which we use the below links to register test metadata and create test DOI:
[https://mds.test.datacite.org/metadata](url)
[https://mds.test.datacite.org/doi](url)
while DOI production repo has similar links without "test" in them.
It requires that all facilities have to make changes if this PR is merged so if no one is interested in having test doi for development I can remove my changes.
Link to any open issues here

## Fixes:

* Remove double prefix in metada xml
*  

## Changes:

* move links for register DOI to config.local.js
* 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
