### PR TITLE
 small changes when debugging issues with connecting catamel to rabbi…

### DIFF
--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -2,16 +2,16 @@
 
 const config = require("../config.local");
 const logger = require("../../common/logger");
-
+const amqp =require("amqplib")
 module.exports = function(app) {
     const rabbitMqEnabled = config.rabbitmq ? config.rabbitmq.enabled : false;
     if (rabbitMqEnabled) {
         let url;
         if (config.rabbitmq.host) {
             if (config.rabbitmq.port) {
-                url = `amqp://${user}:${pass}@${config.rabbitmq.host}:${config.rabbitmq.port}`;
+                url = `amqp://${config.rabbitmq.user}:${config.rabbitmq.pass}@${config.rabbitmq.host}:${config.rabbitmq.port}`;
             } else {
-                url = `amqp://${user}:${pass}@${config.rabbitmq.host}`;
+                url = `amqp://${config.rabbitmq.user}:${config.rabbitmq.pass}@${config.rabbitmq.host}`;
             }
 
             logger.logInfo("Connecting to RabbitMq", { url });

--- a/server/config.local.js-sample
+++ b/server/config.local.js-sample
@@ -24,7 +24,9 @@ module.exports = {
       enabled: false,
       host: null,
       port: null,
-      queue: null
+      queue: null,
+      user: null,
+      pass: null
     },
     smtpSettings: {
       host: 'SMTP.YOUR.DOMAIN',


### PR DESCRIPTION
…tmq server

## Description
When trying to connect catamel to rabbitmq server, an error was thrown by rabbitmq as it could not authenticate the user. I am not sure if this is correct but I have defined the username and passsword in the config.local.js and changed the server/startRabbitMqConsumer.js to pick up the username and password for rabbitmq from the config file. I could not see how or where the original ${user} ${password} in line 13 and 15 was set. 

There was then a second exception thrown as the startRabbitMqConsumer.js could not find amqp. I solved this by importing the amqp library. 

After these two changes I was able to connect to rabbitMq with catamel.


## Motivation 

Link to any open issues here

## Fixes:

* 
*  

## Changes:

* 
* 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?

## Extra Information/Screenshots
