### PR TITLE
Feature/extend dataset history

### DIFF
--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -185,15 +185,16 @@ function updateHistory(ctx, datasetInstances, ctxdatacopy, index, next) {
         // TODO: this ignores any update which contains these fields among other chanegs
         if (!ctx.data.size && !ctx.data.packedSize) {
             const { updatedAt, updatedBy, ...updatedFields } = ctxdatacopy;
+            const historyItem = Object.assign({}, ctxdatacopy);
             Object.keys(updatedFields).forEach((updatedField) => {
-                ctxdatacopy[updatedField] = {
+                historyItem[updatedField] = {
                     currentValue: ctxdatacopy[updatedField],
                     previousValue: datasetInstance[updatedField],
                 };
             });
             // the following triggers a before save hook . endless recursion must be prevented there
             // console.log("=====Calling create with ctx.data:", JSON.stringify(ctx.data, null, 3))
-            datasetInstance.historyList.create(JSON.parse(JSON.stringify(ctxdatacopy).replace(/\$/g, "")), function (err, instance) {
+            datasetInstance.historyList.create(JSON.parse(JSON.stringify(historyItem).replace(/\$/g, "")), function (err, instance) {
                 if (err) {
                     console.log("Saving auto history failed:", err)
                 }

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -29,7 +29,14 @@ exports.transferSizeToDataset = function (obj, sizeField, numFilesField, ctx, ne
                     error.message = 'DatasetId not found. Could be access rule problem - test accessGroups for id: '+instance.pid;
                     next(error)
                 } else {
-                    datasetInstance.updateSize(datasetId, sizeField, instance[sizeField], numFilesField, instance["dataFileList"].length, next)
+                    datasetInstance.updateSize(
+                        datasetId,
+                        sizeField,
+                        instance[sizeField],
+                        numFilesField,
+                        instance["dataFileList"].length,
+                        next
+                    );
                 }
             })
         } else {
@@ -144,7 +151,7 @@ function updateDatasets(ctx, datasetInstances, ctxdatacopy, index, next) {
         // modify ctx.data to keep embedded data
         ctx.data = JSON.parse(JSON.stringify(ctxdatacopy))
         if (ctx.data && ctx.data.datasetlifecycle) {
-            changes = JSON.parse(JSON.stringify(ctx.data.datasetlifecycle))
+            const changes = JSON.parse(JSON.stringify(ctx.data.datasetlifecycle))
             ctx.data.datasetlifecycle = JSON.parse(JSON.stringify(datasetInstances[index].datasetlifecycle))
             // apply changes
             for (var k in changes) ctx.data.datasetlifecycle[k] = changes[k];
@@ -212,8 +219,8 @@ exports.keepHistory = function (ctx, next) {
         }, ctx.options, function (err, datasetInstances) {
             // console.log("++++++ Inside keephistory: Found datasets to be updated:", JSON.stringify(datasetInstances, null, 3))
             // solve asynch call inside for loop by recursion
-            index = datasetInstances.length - 1
-            ctxdatacopy = JSON.parse(JSON.stringify(ctx.data))
+            let index = datasetInstances.length - 1
+            const ctxdatacopy = JSON.parse(JSON.stringify(ctx.data))
             updateDatasets(ctx, datasetInstances, ctxdatacopy, index, next)
         })
     }

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -184,20 +184,16 @@ function updateHistory(ctx, datasetInstances, ctxdatacopy, index, next) {
         // ignore packedsize and size updates for history.
         // TODO: this ignores any update which contains these fields among other chanegs
         if (!ctx.data.size && !ctx.data.packedSize) {
-            const updatedField = Object.keys(ctxdatacopy).find(
-                (field) => field !== "updatedAt" || field !== "updatedBy"
-            );
-            const historyItem = {
-                [updatedField]: {
+            const { updatedAt, updatedBy, ...updatedFields } = ctxdatacopy;
+            Object.keys(updatedFields).forEach((updatedField) => {
+                ctxdatacopy[updatedField] = {
                     currentValue: ctxdatacopy[updatedField],
                     previousValue: datasetInstance[updatedField],
-                },
-                updatedAt: ctxdatacopy.updatedAt,
-                updatedBy: ctxdatacopy.updatedBy,
-            };
+                };
+            });
             // the following triggers a before save hook . endless recursion must be prevented there
             // console.log("=====Calling create with ctx.data:", JSON.stringify(ctx.data, null, 3))
-            datasetInstance.historyList.create(JSON.parse(JSON.stringify(historyItem).replace(/\$/g, "")), function (err, instance) {
+            datasetInstance.historyList.create(JSON.parse(JSON.stringify(ctxdatacopy).replace(/\$/g, "")), function (err, instance) {
                 if (err) {
                     console.log("Saving auto history failed:", err)
                 }

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -184,9 +184,20 @@ function updateHistory(ctx, datasetInstances, ctxdatacopy, index, next) {
         // ignore packedsize and size updates for history.
         // TODO: this ignores any update which contains these fields among other chanegs
         if (!ctx.data.size && !ctx.data.packedSize) {
+            const updatedField = Object.keys(ctxdatacopy).find(
+                (field) => field !== "updatedAt" || field !== "updatedBy"
+            );
+            const historyItem = {
+                [updatedField]: {
+                    currentValue: ctxdatacopy[updatedField],
+                    previousValue: datasetInstance[updatedField],
+                },
+                updatedAt: ctxdatacopy.updatedAt,
+                updatedBy: ctxdatacopy.updatedBy,
+            };
             // the following triggers a before save hook . endless recursion must be prevented there
             // console.log("=====Calling create with ctx.data:", JSON.stringify(ctx.data, null, 3))
-            datasetInstance.historyList.create(JSON.parse(JSON.stringify(ctxdatacopy).replace(/\$/g, "")), function (err, instance) {
+            datasetInstance.historyList.create(JSON.parse(JSON.stringify(historyItem).replace(/\$/g, "")), function (err, instance) {
                 if (err) {
                     console.log("Saving auto history failed:", err)
                 }

--- a/test/DatasetLifecycle.js
+++ b/test/DatasetLifecycle.js
@@ -304,10 +304,15 @@ describe('Test facet and filter queries', () => {
             .expect(200)
             .expect('Content-Type', /json/)
             .end((err, res) => {
-                //console.log("Resulting history in first raw:", JSON.stringify(res.body, null, 4))
+                // console.log("Resulting history in first raw:", JSON.stringify(res.body, null, 4))
                 res.body.should.have.nested
                     .property(
-                        "history[1].datasetlifecycle.archiveStatusMessage.currentValue"
+                        "history[1].datasetlifecycle.previousValue.archiveStatusMessage"
+                    )
+                    .and.equal("dataArchivedOnTape");
+                res.body.should.have.nested
+                    .property(
+                        "history[1].datasetlifecycle.currentValue.archiveStatusMessage"
                     )
                     .and.equal("justAnotherTestMessage");
 
@@ -326,7 +331,12 @@ describe('Test facet and filter queries', () => {
                 // console.log("Resulting history in second raw:", JSON.stringify(res.body, null, 4))
                 res.body.should.have.nested
                     .property(
-                        "history[0].datasetlifecycle.archiveStatusMessage.currentValue"
+                        "history[0].datasetlifecycle.previousValue.archiveStatusMessage"
+                    )
+                    .and.equal("datasetCreated");
+                res.body.should.have.nested
+                    .property(
+                        "history[0].datasetlifecycle.currentValue.archiveStatusMessage"
                     )
                     .and.equal("justAnotherTestMessage");
                 done();

--- a/test/DatasetLifecycle.js
+++ b/test/DatasetLifecycle.js
@@ -305,7 +305,11 @@ describe('Test facet and filter queries', () => {
             .expect('Content-Type', /json/)
             .end((err, res) => {
                 //console.log("Resulting history in first raw:", JSON.stringify(res.body, null, 4))
-                res.body.should.have.nested.property('history[1].datasetlifecycle.archiveStatusMessage').and.equal("justAnotherTestMessage");
+                res.body.should.have.nested
+                    .property(
+                        "history[1].datasetlifecycle.archiveStatusMessage.currentValue"
+                    )
+                    .and.equal("justAnotherTestMessage");
 
                 done();
             });
@@ -320,7 +324,11 @@ describe('Test facet and filter queries', () => {
             .expect('Content-Type', /json/)
             .end((err, res) => {
                 // console.log("Resulting history in second raw:", JSON.stringify(res.body, null, 4))
-                res.body.should.have.nested.property('history[0].datasetlifecycle.archiveStatusMessage').and.equal("justAnotherTestMessage");
+                res.body.should.have.nested
+                    .property(
+                        "history[0].datasetlifecycle.archiveStatusMessage.currentValue"
+                    )
+                    .and.equal("justAnotherTestMessage");
                 done();
             });
 


### PR DESCRIPTION
## Description

Extend Dataset.historyList to include the previous value. New structure:
```js
{
    [updatedField]: {
        currentValue: "",
        previousValue: ""
    },
    updatedAt: "",
    updatedBy: ""
}
```

## Motivation 

Prevent loss of information.

## Changes:

* Fix warnings in common/models/utils.js
*  Extend items in Dataset.historyList to include both current and previous value
* Update unit tests for the new structure

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?
