### PR TITLE
Feature/remove objectIds

### DIFF
--- a/client/api/createAngularAPI.sh
+++ b/client/api/createAngularAPI.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd ../../..
-./catamel/node_modules/.bin/lb-sdk catamel/server/server.js  ../catanie/catanie/src/app/shared/sdk
+./catamel/node_modules/.bin/lb-sdk catamel/server/server.js  ./catanie/src/app/shared/sdk
 cd -

--- a/common/models/attachment.json
+++ b/common/models/attachment.json
@@ -2,11 +2,16 @@
   "name": "Attachment",
   "description": "Small less than 16 MB attachments, envisaged for png/jpeg previews",
   "base": "Ownable",
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
   "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "defaultFn": "uuidv4"
+    },
     "thumbnail": {
       "type": "string",
       "required": true,

--- a/common/models/dataset-lifecycle.json
+++ b/common/models/dataset-lifecycle.json
@@ -3,7 +3,7 @@
   "description": "For each dataset there exists an embedded dataset lifecycle document which describes the current status of the dataset during its lifetime with respect to the storage handling systems",
   "base": "Model",
   "strict": true,
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },

--- a/common/models/dataset.json
+++ b/common/models/dataset.json
@@ -150,11 +150,6 @@
             "model": "PublishedData",
             "foreignKey": ""
         },
-        "samples": {
-            "type": "hasMany",
-            "model": "Sample",
-            "foreignKey": ""
-        },
         "origdatablocks": {
             "type": "hasMany",
             "model": "OrigDatablock",

--- a/common/models/job.js
+++ b/common/models/job.js
@@ -426,7 +426,7 @@ module.exports = function (Job) {
     });
 
     Job.observe('after save', (ctx, next) => {
-        if (ctx.instance) {
+        if (ctx.instance && ctx.instance.datasetList) {
             // first create array of all pids
             const idList = ctx.instance.datasetList.map(x => x.pid)
             // get policy parameters for pgroup/proposal of first dataset

--- a/common/models/job.json
+++ b/common/models/job.json
@@ -3,7 +3,7 @@
     "description": "This collection keeps information about jobs to be excuted in external systems. In particular it keeps information about the jobs submitted for archiving or retrieving datasets stored inside an archive system. It can also be used to keep track of analysis jobs e.g. for automated analysis workflows.",
     "base": "MongoQueryableModel",
     "strict": true,
-    "idInjection": true,
+    "idInjection": false,
     "options": {
         "validateUpsert": true
     },
@@ -18,6 +18,11 @@
         }
     },
     "properties": {
+        "id": {
+            "type": "string",
+            "id": true,
+            "defaultFn": "uuidv4"
+        },
         "emailJobInitiator": {
             "type": "string",
             "required": true,
@@ -50,7 +55,7 @@
         },
         "datasetList": {
             "type": "object",
-            "required": true,
+            "required": false,
             "description": "Array of objects with keys: pid, files. The value for the pid key defines the dataset ID, the value for the files key is an array of file names. This array is either an empty array, implying that all files within the dataset are selected or an explicit list of dataset-relative file paths, which should be selected"
         },
         "jobResultObject": {

--- a/common/models/measurement-period.json
+++ b/common/models/measurement-period.json
@@ -3,7 +3,7 @@
   "description": "Embedded information used inside proposals to define which type of experiment as to be pursued where (at which intrument) and when.",
   "base": "MongoQueryableModel",
   "strict": true,
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
@@ -12,7 +12,8 @@
       "type": "string",
       "id": "true",
       "required": true,
-      "description": "id currently needed by limitation in embedsmany"
+      "description": "id currently needed by limitation in embedsmany",
+      "defaultFn": "uuidv4"
     },
     "instrument": {
       "type": "string",

--- a/common/models/message.json
+++ b/common/models/message.json
@@ -3,7 +3,7 @@
   "description": "To get auto-created history information.",
   "base": "Model",
   "strict": false,
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
@@ -12,7 +12,7 @@
       "type": "string",
       "id": "true",
       "description": "id currently needed by limitation in embedsmany",
-      "defaultFn": "uuid"
+      "defaultFn": "uuidv4"
     }
   },
   "validations": [],

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -169,7 +169,7 @@ module.exports = function (MongoQueryableModel) {
                     pipeline.push({
                         $match: currentExpression
                     });
-                    modeMatch=currentExpression
+                    modeMatch = currentExpression
                 } else if (key === "userGroups") {
                     // no group conditions if global access role
                     if (fields["userGroups"].indexOf("globalaccess") < 0) {
@@ -261,7 +261,7 @@ module.exports = function (MongoQueryableModel) {
 
         // add pipeline to count all documents, take into account unwinding case for (Orig)Datablock
         // TODO correct facet handling with actual facets (not just "all") when (Orig)Datablock is used
-    
+
         if (options.modelName === "OrigDatablock" || options.modelName === "Datablock") {
             // console.log("Adding additional pipeline steps for unwinding file names:")
             if (modeMatch) {
@@ -279,14 +279,14 @@ module.exports = function (MongoQueryableModel) {
                 ];
             } else {
                 facetObject["all"] = [{
-                    $match: facetMatch
-                },
-                {
-                    "$unwind": "$dataFileList"
-                }, {
-                    $count: "totalSets"
-                }
-            ];
+                        $match: facetMatch
+                    },
+                    {
+                        "$unwind": "$dataFileList"
+                    }, {
+                        $count: "totalSets"
+                    }
+                ];
 
             }
 
@@ -463,7 +463,7 @@ module.exports = function (MongoQueryableModel) {
                     // map id field
                     let fieldName = parts[0]
                     let idField = app.models[modelName].getIdName()
-                    // console.log("Derived idField:",idField)
+                    // console.log("Derived idField:", idField)
                     if (fieldName == idField) {
                         fieldName = "_id"
                     }
@@ -504,7 +504,7 @@ module.exports = function (MongoQueryableModel) {
                     }
                     // rename _id to id Field name
                     let idField = app.models[modelName].getIdName()
-                    // console.log("Derived idField:", idField)
+                    // console.log("Derived idField 2:", idField)
                     res.map(ds => {
                         Object.defineProperty(
                             ds,

--- a/common/models/orig-datablock.json
+++ b/common/models/orig-datablock.json
@@ -3,7 +3,7 @@
     "description": "Container list all files and their attributes which make up a dataset. Usually Filled at the time the datasets metadata is created in the data catalog. Can be used by subsequent archiving processes to create the archived datasets.",
     "base": "Ownable",
     "strict": true,
-    "idInjection": true,
+    "idInjection": false,
     "indexes": {
         "datasetId_index": {
             "keys": {
@@ -22,8 +22,8 @@
     "properties": {
         "id": {
             "type": "string",
-            "required": true,
-            "description": "Automatically created ID"
+            "id": true,
+            "defaultFn": "uuidv4"
         },
         "size": {
             "type": "number",

--- a/common/models/ownable.json
+++ b/common/models/ownable.json
@@ -3,7 +3,7 @@
   "description": "This is the base model for all models which 'belong' to entities like pgroups. It is crucial to implemtn a user dependent access control to datasets or other ownable documents.",
   "base": "MongoQueryableModel",
   "strict": true,
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },

--- a/common/models/policy.json
+++ b/common/models/policy.json
@@ -3,11 +3,16 @@
   "description": "Definition of policy parameters relevant for the storgae lifecycle management of the datasets",
   "plural": "Policies",
   "base": "Ownable",
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
   "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "defaultFn": "uuidv4"
+    },
     "manager": {
       "type": [
         "string"

--- a/common/models/sample.json
+++ b/common/models/sample.json
@@ -3,14 +3,15 @@
     "description": "Models describing the characteristics of the samples to be investigated. Raw datasets should be linked to such sample definitions.",
     "base": "Ownable",
     "strict": true,
-    "idInjection": true,
+    "idInjection": false,
     "options": {
         "validateUpsert": true
     },
     "properties": {
         "sampleId": {
             "type": "string",
-            "id": true
+            "id": true,
+            "defaultFn": "uuidv4"
         },
         "owner": {
             "type": "string"

--- a/common/models/sample.json
+++ b/common/models/sample.json
@@ -38,8 +38,8 @@
             "foreignKey": ""
         },
         "datasets": {
-            "type": "belongsTo",
-            "model": "Dataset",
+            "type": "hasMany",
+            "model": "RawDataset",
             "foreignKey": ""
         }
     },

--- a/common/models/user-setting.json
+++ b/common/models/user-setting.json
@@ -2,11 +2,16 @@
   "name": "UserSetting",
   "description": "User settings such as job count and dataset count",
   "base": "MongoQueryableModel",
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
   "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "defaultFn": "uuidv4"
+    },
     "columns": {
       "type": [
         "object"

--- a/scripts/replaceObjectIds.js
+++ b/scripts/replaceObjectIds.js
@@ -1,0 +1,16 @@
+names = ["Job", "Policy", "Sample", "UserSetting", "Attachment", "OrigDatablock"]
+for (var i = 0; i < names.length; i++) {
+    coll = db[names[i]]
+    coll.find({
+        _id: {
+            $type: "objectId"
+        }
+    }).forEach(function (x) {
+        var oldId = x._id;
+        x._id = x._id.valueOf(); // convert field to string
+        coll.insert(x);
+        coll.remove({
+            _id: oldId
+        });
+    });
+}

--- a/scripts/replaceObjectIds.sh
+++ b/scripts/replaceObjectIds.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# this command should be executed once after deploying catamel commit
+# c592879d656b84f322cd062ff4ca56d45d4d10cd Date:   Tue Jan 19 12:54:58 2021 +0100
+# or later
+# It replaces all ObjectID based ids to normal strings in many SciCat tables
+# it uses the mongo client for this, so you must adjust the host and password parameters
+echo " Adjust the following line and uncomment"
+# mongo -u "dacatDBAdmin" -p "...."  --authenticationDatabase "dacat" HOSTNAME/dacat  replaceObjectIds.js

--- a/test/Datablock.js
+++ b/test/Datablock.js
@@ -246,7 +246,7 @@ describe('Test Datablocks and OrigDatablocks and their relation to raw Datasets'
             .end(function (err, res) {
                 if (err)
                     return done(err);
-                //console.log("origdatablock:",res.body)
+                console.log("origdatablock:",res.body)
                 res.body.should.have.property('size').and.equal(41780189);
                 res.body.should.have.property('id').and.be.string;
                 idOrigDatablock = encodeURIComponent(res.body['id']);
@@ -518,11 +518,13 @@ describe('Test Datablocks and OrigDatablocks and their relation to raw Datasets'
 
     it('should delete a OrigDatablock', function (done) {
         request(app)
-            .delete('/api/v3/Datablocks/' + idOrigDatablock + '?access_token=' + accessTokenArchiveManager)
+            .delete('/api/v3/OrigDatablocks/' + idOrigDatablock + '?access_token=' + accessTokenArchiveManager)
             .set('Accept', 'application/json')
             .expect(200)
             .expect('Content-Type', /json/)
             .end((err, res) => {
+                res.body.should.have.property('count').and.equal(1);
+                // console.log("===== Delete OrigDatablock :",JSON.stringify(res.body,null,4),err)
                 if (err)
                     return done(err);
                 done();

--- a/test/DatablockDerived.js
+++ b/test/DatablockDerived.js
@@ -353,11 +353,13 @@ describe('Test Datablocks and OrigDatablocks and their relation to Derived Datas
 
     it('should delete a OrigDatablock', function(done) {
         request(app)
-            .delete('/api/v3/Datablocks/' + idOrigDatablock + '?access_token=' + accessTokenArchiveManager)
+            .delete('/api/v3/OrigDatablocks/' + idOrigDatablock + '?access_token=' + accessTokenArchiveManager)
             .set('Accept', 'application/json')
             .expect(200)
             .expect('Content-Type', /json/)
             .end((err, res) => {
+                res.body.should.have.property('count').and.equal(1);
+                // console.log("===== Delete OrigDatablock :",JSON.stringify(res.body,null,4),err)
                 if (err)
                     return done(err);
                 done();

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -503,11 +503,13 @@ describe("Test of access to published data", () => {
 
     it('should delete a OrigDatablock', function (done) {
         request(app)
-            .delete('/api/v3/Datablocks/' + idOrigDatablock + '?access_token=' + accessTokenArchiveManager)
+            .delete('/api/v3/OrigDatablocks/' + idOrigDatablock + '?access_token=' + accessTokenArchiveManager)
             .set('Accept', 'application/json')
             .expect(200)
             .expect('Content-Type', /json/)
             .end((err, res) => {
+                res.body.should.have.property('count').and.equal(1);
+                // console.log("===== Delete OrigDatablock :",JSON.stringify(res.body,null,4),err)
                 if (err)
                     return done(err);
                 done();


### PR DESCRIPTION
## Important:
**You need to run the script catamel/scripts/replaceObjectIds.sh once** on your Mongo DB after deploying this version of catamel in order to profit from the new query options. Please adjust the script to your connection settings. The script effectively modifies the existing ObjectIDs to strings

## Description
Make sure that the IDs inside all SciCat Mongo collections are strings and not ObjectIds

## Motivation 
* Unification of ID handling across all collections
* extended and generalized support for querying by ID (substring search)

## Fixes:
* Without this change there is a mixture of ObjectID and string based IDs
*  One could not search for substrings inside IDs before

## Important:
**You need to run the script catamel/scripts/replaceObjectIds.sh once** on your Mongo DB after deploying this version of catamel in order to profit from the new query options. Please adjust the script to your connection settings. The script effectively modifies the existing ObjectIDs to strings
