### PR TITLE
Allow metadata field without unit and value

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -160,7 +160,7 @@ module.exports = function(Dataset) {
         scientificMetadata
       } = ctx.args.data;
       Object.keys(scientificMetadata).forEach(key => {
-        if (scientificMetadata[key].unit?.length > 0) {
+        if (scientificMetadata[key].unit && scientificMetadata[key].unit.length > 0) {
           const {
             value,
             unit

--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -160,7 +160,7 @@ module.exports = function(Dataset) {
         scientificMetadata
       } = ctx.args.data;
       Object.keys(scientificMetadata).forEach(key => {
-        if (scientificMetadata[key].unit.length > 0) {
+        if (scientificMetadata[key].unit?.length > 0) {
           const {
             value,
             unit
@@ -302,7 +302,7 @@ module.exports = function(Dataset) {
         console.log("      New pid:", ctx.instance.pid);
         /* fill default datasetlifecycle
                     warning: need to transfer datasetlifecycle to a normal object first,
-                    otherwise key tests give wrong results due to some "wrapping" of 
+                    otherwise key tests give wrong results due to some "wrapping" of
                     the objects behind functions in loopback magic
                 */
         var subblock = {};
@@ -802,7 +802,7 @@ module.exports = function(Dataset) {
           lm.limit = MAXLIMIT;
         }
         limits = lm;
-      } 
+      }
 
       logger.logInfo("Fetching metadataKeys", {
         fields,

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -8,7 +8,7 @@ module.exports = function (MongoQueryableModel) {
 
   function loopbackTypeOf(modelName, key, value = null) {
     // console.log("type extraction:", modelName, key)
-    // extract type. For arrays this returns undefined. See 
+    // extract type. For arrays this returns undefined. See
     // https://stackoverflow.com/questions/52916635/how-do-you-access-loopback-model-property-types-model-definition-properties-ty
     let property = app.models[modelName].definition.properties[key];
     // Also check derived Datasets
@@ -238,7 +238,7 @@ module.exports = function (MongoQueryableModel) {
     facets.forEach(function (facet) {
       // console.log("Facet.modelName,properties:", facet, modelName, app.models[modelName].definition.properties)
       // for inheritance Dataset test parent models as well
-      // TODO make this generic by checking for same collection setting in the models 
+      // TODO make this generic by checking for same collection setting in the models
       if (modelName == "Dataset") {
         if (facet in app.models["RawDataset"].definition.properties) {
           facetObject[facet] = utils.createNewFacetPipeline(
@@ -595,7 +595,7 @@ module.exports = function (MongoQueryableModel) {
       }
       // however allow history updates
       if (!ctx.data["history"] && ctx.currentInstance) {
-        // modify operations are forbidden unless you are member of ownerGroup or have globalaccess role  
+        // modify operations are forbidden unless you are member of ownerGroup or have globalaccess role
         if ((groups.indexOf("globalaccess") < 0) && !ctx.isNewInstance && groups.indexOf(ctx.currentInstance.ownerGroup) < 0) {
           var e = new Error();
           e.statusCode = 403;
@@ -664,7 +664,7 @@ module.exports = function (MongoQueryableModel) {
         scientificMetadata
       } = ctx.args.data;
       Object.keys(scientificMetadata).forEach(key => {
-        if (scientificMetadata[key].unit.length > 0) {
+        if (scientificMetadata[key].unit?.length > 0) {
           const {
             value,
             unit

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -664,7 +664,7 @@ module.exports = function (MongoQueryableModel) {
         scientificMetadata
       } = ctx.args.data;
       Object.keys(scientificMetadata).forEach(key => {
-        if (scientificMetadata[key].unit?.length > 0) {
+        if (scientificMetadata[key].unit && scientificMetadata[key].unit.length > 0) {
           const {
             value,
             unit


### PR DESCRIPTION
## Description

At the moment all fields in scientific metadata must have value of type {value: "some value", unit: "some unit"} even for field that  is not a physical quantity. I added a small change to support both which means it is possible to have value and unit on all field and it is also possible to just have value when the field is not a physical quantity.

## Motivation
Can't save metadata to database if a field only contain value

## Usage
Way 1: 
```
{ 
  "a physical quantity": { value": 1, "unit": "eV"},
  "not a physical quantity": {value": "some value", "unit": ""} 
}
```
Way 2
```
{ 
  "a physical quantity": { value": 1, "unit": "eV"},
  "not a physical quantity":"some value"
}
```
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
