### PR TITLE
Allow logged in user to see published dataset

### DIFF
--- a/common/models/ownable.js
+++ b/common/models/ownable.js
@@ -25,7 +25,7 @@ module.exports = function (Ownable) {
               inq: groups
             }
           },
-          {isPublished: true}
+          { isPublished: true }
           ]
         };
         if (!ctx.query.where) {

--- a/common/models/ownable.js
+++ b/common/models/ownable.js
@@ -24,7 +24,8 @@ module.exports = function (Ownable) {
             accessGroups: {
               inq: groups
             }
-          }
+          },
+          {isPublished: true}
           ]
         };
         if (!ctx.query.where) {


### PR DESCRIPTION
## Description
User can not see published dataset while being logged in. This is because of the query filter, it only returns datasets belong to a owner group or access group
## Fixes:
Added an extra field to include published dataset 
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
