### PR TITLE
Chore/579/useroffice proposal

### DIFF
--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -69,13 +69,13 @@ module.exports = function (app) {
                 let proposalData = {
                   "proposalId" : payload.shortCode,
                   "title" : payload.title,
-                  "pi_email" : ( payload.members.length > 0 ? payload.members[0].email : ( "proposer" in payload ? payload.proposer.email : "unknown@ess.eu" )),
-                  "pi_firstname" : ( payload.members.length > 0 ? payload.members[0].firstName : ( "proposer" in payload ? payload.proposer.firstName : "" )),
-                  "pi_lastname" : ( payload.members.length > 0 ? payload.members[0].lastName : ( "proposer" in payload ? payload.proposer.lastName : "" )),
-                  "email" : ( "proposer" in payload ? payload.proposer.email : ( payload.members.length > 0 ? payload.members[0].email : "unknown@ess.eu")),
-                  "firstname" : ( "proposer" in payload ? payload.proposer.firstName : ( payload.members.length > 0 ? payload.members[0].firstName : "")),
-                  "lastname" : ( "proposer" in payload ? payload.proposer.lastName : ( payload.members.length > 0 ? payload.members[0].lastName : "")),
-                  "abstract" : "",
+                  "pi_email" : payload.proposer.email,
+                  "pi_firstname" : payload.proposer.firstName,
+                  "pi_lastname" : payload.proposer.lastName,
+                  "email" : payload.proposer.email,
+                  "firstname" : payload.proposer.firstName,
+                  "lastname" : payload.proposer.lastName,
+                  "abstract" : payload.asbtract,
                   "ownerGroup" : "ess",
                   "createdBy" : "proposalIngestor"
                 };

--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -113,8 +113,6 @@ module.exports = function (app) {
                 location: "channel.consume"
               });
             }
-            // we acknowledge the message no matter what, at least for now
-            //channel.ack(msg);
           },
           {
             noAck: false

--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -69,12 +69,12 @@ module.exports = function (app) {
                 let proposalData = {
                   "proposalId" : payload.shortCode,
                   "title" : payload.title,
-                  "pi_email" : ( payload.members.length > 0 ? payload.members[0].email : ( "proposer" in payload ? payload.proposer.email : 'unknown@ess.eu' )),
-                  "pi_firstname" : ( payload.members.length > 0 ? payload.members[0].firstName : ( "proposer" in payload ? payload.proposer.firstName : '' )),
-                  "pi_lastname" : ( payload.members.length > 0 ? payload.members[0].lastName : ( "proposer" in payload ? payload.proposer.lastName : '' )),
-                  "email" : ( "proposer" in payload ? payload.proposer.email : ( payload.members.length > 0 ? payload.members[0].email : 'unknown@ess.eu')),
-                  "firstname" : ( "proposer" in payload ? payload.proposer.firstName : ( payload.members.length > 0 ? payload.members[0].firstName : '')),
-                  "lastname" : ( "proposer" in payload ? payload.proposer.lastName : ( payload.members.length > 0 ? payload.members[0].lastName : '')),
+                  "pi_email" : ( payload.members.length > 0 ? payload.members[0].email : ( "proposer" in payload ? payload.proposer.email : "unknown@ess.eu" )),
+                  "pi_firstname" : ( payload.members.length > 0 ? payload.members[0].firstName : ( "proposer" in payload ? payload.proposer.firstName : "" )),
+                  "pi_lastname" : ( payload.members.length > 0 ? payload.members[0].lastName : ( "proposer" in payload ? payload.proposer.lastName : "" )),
+                  "email" : ( "proposer" in payload ? payload.proposer.email : ( payload.members.length > 0 ? payload.members[0].email : "unknown@ess.eu")),
+                  "firstname" : ( "proposer" in payload ? payload.proposer.firstName : ( payload.members.length > 0 ? payload.members[0].firstName : "")),
+                  "lastname" : ( "proposer" in payload ? payload.proposer.lastName : ( payload.members.length > 0 ? payload.members[0].lastName : "")),
                   "abstract" : "",
                   "ownerGroup" : "ess",
                   "createdBy" : "proposalIngestor"

--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -78,7 +78,7 @@ module.exports = function (app) {
                   "abstract" : "",
                   "ownerGroup" : "ess",
                   "createdBy" : "proposalIngestor"
-                }
+                };
                 logger.logInfo(
                   "SciCat proposal data",
                   {

--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -77,8 +77,8 @@ module.exports = function (app) {
                     "firstname" : ( "proposer" in payload ? payload.proposer.firstName : ( payload.members.length > 0 ? payload.members[0].firstName : '')),
                     "lastname" : ( "proposer" in payload ? payload.proposer.lastName : ( payload.members.length > 0 ? payload.members[0].lastName : '')),
                     "abstract" : "",
-                    "startTime" : "",
-                    "endTime" : ""
+                    "ownerGroup" : "ess",
+                    "createdBy" : "proposalIngestor"
                   }
                   logger.logInfo(
                     "SciCat proposal data",
@@ -114,7 +114,7 @@ module.exports = function (app) {
               });
             }
             // we acknowledge the message no matter what, at least for now
-            channel.ack(msg);
+            //channel.ack(msg);
           },
           {
             noAck: false


### PR DESCRIPTION
## Description

Integrated scicat proposal creation with useroffice proposal acccepted through rabbitmq

## Motivation

This change will allow scicat to listen on the rabbitmq queue where useroffice publish a message when a proposal is accepted. Once scicat receives the proposal accepted message, will create the proposal locally for user consumption.
Following assumptions have been made on field mapping: 
* scicat Pi info are populated from the first element of the member field if exists, otherwise from the proposer or left empty except for a fake email
* scicat proposer info are populated from scicat proposer if exists. Otherwise from the first element of the member field if exist or left empty except for a fake email


## Changes:

* refactored server/boot/startRabbitMqConsumer.js to accept the current Propsal Accepte message format and populate accordingly the scicat proposal.

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
