### PR TITLE
Feature/multilevel scientific metadata

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -10,6 +10,7 @@ var ds = require("./dataset.json");
 var dsr = require("./raw-dataset.json");
 var dsd = require("./derived-dataset.json");
 var own = require("./ownable.json");
+const lodash = require("lodash");
 const logger = require("../logger");
 // TODO Feature  Add delete functionality for dataset, which removes Dataset and all linked data:
 // OrigDatablock and Datablock and DatasetAttachments
@@ -174,21 +175,19 @@ module.exports = function(Dataset) {
           lhs,
           unit
         }) => {
-          if (
-            lhs in scientificMetadata &&
-                        scientificMetadata[lhs].unit.length > 0 &&
-                        scientificMetadata[lhs].unit !== unit
-          ) {
+          const currentUnit = lodash.get(scientificMetadata, `${lhs}.unit`);
+          const currentValue = lodash.get(scientificMetadata, `${lhs}.value`);
+          if (currentUnit && currentUnit !== unit) {
             const {
               valueRequested,
               unitRequested,
             } = utils.convertToRequestedUnit(
-              scientificMetadata[lhs].value,
-              scientificMetadata[lhs].unit,
+              currentValue,
+              currentUnit,
               unit
             );
-            scientificMetadata[lhs].value = valueRequested;
-            scientificMetadata[lhs].unit = unitRequested;
+            lodash.update(scientificMetadata, `${lhs}.unit`, () => {return unitRequested;});
+            lodash.update(scientificMetadata, `${lhs}.value`, () => {return valueRequested;});
           }
         });
       });

--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -820,9 +820,6 @@ module.exports = function(Dataset) {
         logger.logInfo("No someCollections found", { someCollections });
       }
 
-
-      logger.logInfo("Raw metadata array", { count: metadata.length });
-
       const metadataKeys = utils.extractMetadataKeys(someCollections).filter(key => !blacklist.some(regex => regex.test(key)));
 
       logger.logInfo("Curated metadataKeys", {

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -680,21 +680,19 @@ module.exports = function (MongoQueryableModel) {
           lhs,
           unit
         }) => {
-          if (
-            lhs in scientificMetadata &&
-                        scientificMetadata[lhs].unit.length > 0 &&
-                        scientificMetadata[lhs].unit !== unit
-          ) {
+          const currentUnit = lodash.get(scientificMetadata, `${lhs}.unit`);
+          const currentValue = lodash.get(scientificMetadata, `${lhs}.value`);
+          if (currentUnit && currentUnit !== unit) {
             const {
               valueRequested,
               unitRequested,
             } = utils.convertToRequestedUnit(
-              scientificMetadata[lhs].value,
-              scientificMetadata[lhs].unit,
+              currentValue,
+              currentUnit,
               unit
             );
-            scientificMetadata[lhs].value = valueRequested;
-            scientificMetadata[lhs].unit = unitRequested;
+            lodash.update(scientificMetadata, `${lhs}.unit`, () => {return unitRequested;});
+            lodash.update(scientificMetadata, `${lhs}.value`, () => {return valueRequested;});
           }
         });
       });

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -1,6 +1,6 @@
 "use strict";
 const utils = require("./utils");
-
+const lodash = require("lodash");
 module.exports = function (MongoQueryableModel) {
 
   // to get access to other models

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -589,7 +589,7 @@ module.exports = function (MongoQueryableModel) {
     // make sure that only ownerGroup members have modify rights
     if (ctx.data && ctx.options && !ctx.options.validate) {
       let groups = [];
-      // ctx.options is not empty 
+      // ctx.options is not empty
       if (ctx.options.currentGroups) {
         // ("Your groups are:", ctx.options.currentGroups)
         groups = ctx.options.currentGroups;
@@ -661,26 +661,8 @@ module.exports = function (MongoQueryableModel) {
     next
   ) {
     if ("scientificMetadata" in ctx.args.data) {
-      const {
-        scientificMetadata
-      } = ctx.args.data;
-      Object.keys(scientificMetadata).forEach(key => {
-        if (scientificMetadata[key] && scientificMetadata[key].unit && scientificMetadata[key].unit.length > 0) {
-          const {
-            value,
-            unit
-          } = scientificMetadata[key];
-          const {
-            valueSI,
-            unitSI
-          } = utils.convertToSI(value, unit);
-          scientificMetadata[key] = {
-            ...scientificMetadata[key],
-            valueSI,
-            unitSI
-          };
-        }
-      });
+      const { scientificMetadata } = ctx.args.data;
+      utils.appendSIUnitToPhysicalQuantity(scientificMetadata);
     }
     next();
   });

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -717,15 +717,23 @@ module.exports = function (MongoQueryableModel) {
             modelName === "Dataset" ?
               "scientificMetadata" :
               "sampleCharacteristics";
-    const matchKeyGeneric = `${parameterFieldName}.${lhs}.value`;
+    const matchKeyGeneric = `${parameterFieldName}.${lhs}`;
     const matchKeyMeasurement = `${parameterFieldName}.${lhs}.valueSI`;
     const matchUnit = `${parameterFieldName}.${lhs}.unitSI`;
     switch (relation) {
     case "EQUAL_TO_STRING": {
       match.$and.push({
-        [matchKeyGeneric]: {
-          $eq: rhs,
+        $or: [{
+          [matchKeyGeneric]: {
+            $eq: rhs,
+          }
         },
+        {
+          [`${matchKeyGeneric}.value`]: {
+            $eq: rhs,
+          }
+        }
+        ]
       });
       break;
     }
@@ -747,9 +755,16 @@ module.exports = function (MongoQueryableModel) {
         });
       } else {
         match.$and.push({
-          [matchKeyGeneric]: {
-            $eq: rhs,
+          $or: [{
+            [matchKeyGeneric]: {
+              $eq: rhs,
+            }
           },
+          {
+            [`${matchKeyGeneric}.value`]: {
+              $eq: rhs,
+            }
+          }]
         });
       }
       break;
@@ -772,9 +787,17 @@ module.exports = function (MongoQueryableModel) {
         });
       } else {
         match.$and.push({
-          [matchKeyGeneric]: {
-            $gt: rhs,
+          $or: [{
+            [matchKeyGeneric]: {
+              $gt: rhs,
+            }
           },
+          {
+            [`${matchKeyGeneric}.value`]: {
+              $gt: rhs,
+            }
+          }
+          ]
         });
       }
       break;
@@ -797,9 +820,16 @@ module.exports = function (MongoQueryableModel) {
         });
       } else {
         match.$and.push({
-          [matchKeyGeneric]: {
-            $lt: rhs,
+          $or: [{
+            [matchKeyGeneric]: {
+              $lt: rhs,
+            }
           },
+          {
+            [`${matchKeyGeneric}.value`]: {
+              $lt: rhs,
+            }
+          }]
         });
       }
       break;

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -369,7 +369,7 @@ exports.convertToRequestedUnit = (value, currentUnit, requestedUnit) => {
 };
 
 exports.appendSIUnitToPhysicalQuantity = (object) => {
-  return Object.keys(object).forEach((key) => {
+  Object.keys(object).forEach((key) => {
     const value = object[key];
     if (value?.unit) {
       const {

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -371,7 +371,7 @@ exports.convertToRequestedUnit = (value, currentUnit, requestedUnit) => {
 exports.appendSIUnitToPhysicalQuantity = (object) => {
   Object.keys(object).forEach((key) => {
     const value = object[key];
-    if (value?.unit) {
+    if (value && value.unit) {
       const {
         valueSI,
         unitSI
@@ -387,36 +387,36 @@ exports.appendSIUnitToPhysicalQuantity = (object) => {
       exports.appendSIUnitToPhysicalQuantity(value);
     }
   });
-}
+};
 /**Check if input is object or a physical quantity */
 const isObject = (x) => {
-    if(x && typeof x === 'object' && (!Array.isArray(x) && (!x.unit && x.unit !== ""))){
-        return true;
-    }
-    return false;
-}
+  if(x && typeof x === "object" && (!Array.isArray(x) && (!x.unit && x.unit !== ""))){
+    return true;
+  }
+  return false;
+};
 exports.extractMetadataKeys = (datasetArray) => {
-    const keys = new Set();
-    //Return nested keys in this structure parentkey.childkey.grandchildkey....
-    const flattenKeys = (object, keyStr) => {
-        Object.keys(object).forEach((key) => {
-            const value = object[key];
-            const newKeyStr = `${keyStr? keyStr + '.': ""}${key}`;
-            if (isObject(value)) {
-                flattenKeys(value, newKeyStr);
-            } else {
-                keys.add(newKeyStr);
-            }
-        });
-    }
-    datasetArray.forEach((dataset) => {
-        const { scientificMetadata } = dataset;
-        if (scientificMetadata) {
-            flattenKeys(scientificMetadata, "");
-        }
+  const keys = new Set();
+  //Return nested keys in this structure parentkey.childkey.grandchildkey....
+  const flattenKeys = (object, keyStr) => {
+    Object.keys(object).forEach((key) => {
+      const value = object[key];
+      const newKeyStr = `${keyStr? keyStr + ".": ""}${key}`;
+      if (isObject(value)) {
+        flattenKeys(value, newKeyStr);
+      } else {
+        keys.add(newKeyStr);
+      }
     });
-    return Array.from(keys);
-}
+  };
+  datasetArray.forEach((dataset) => {
+    const { scientificMetadata } = dataset;
+    if (scientificMetadata) {
+      flattenKeys(scientificMetadata, "");
+    }
+  });
+  return Array.from(keys);
+};
 /*
  wrapper to superagent library to make it ace as the request-response library
  passing in a single data structure with all the info and options to define the full request

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,8 +26,8 @@ const superagentTests = {
       "content-type": "application/xml;charset=UTF-8",
     },
     auth: {
-      "username" : "a_user",
-      "password" : "the_password"
+      "username": "a_user",
+      "password": "the_password"
     },
   }
 };
@@ -57,15 +57,16 @@ describe("utils.superagent", () => {
 
 describe("utils.appendSIUnitToPhysicalQuantity", () => {
 
-    it("should append SI Unit to physical quantity", () => {
-      const res = utils.appendSIUnitToPhysicalQuantity(utilsTestData.testData);
-      chai.expect(res).to.deep.equal(utilsTestData.appendSIUnitToPhysicalQuantityExpectedData);
-    });
+  it("should append SI Unit to physical quantity", () => {
+    const testData = { ...utilsTestData.testData.scientificMetadata }
+    utils.appendSIUnitToPhysicalQuantity(testData);
+    chai.expect(testData).to.deep.equal(utilsTestData.appendSIUnitToPhysicalQuantityExpectedData);
+  });
 });
 
 describe("utils.extractMetadataKeys", () => {
-    it("should return a array of unique keys", () => {
-      const res = utils.extractMetadataKeys([utilsTestData.testData]);
-      chai.expect(res).to.deep.equal(utilsTestData.extractMetadataKeysExpectedData);
-    });
+  it("should return a array of unique keys", () => {
+    const res = utils.extractMetadataKeys([utilsTestData.testData]);
+    chai.expect(res).to.deep.equal(utilsTestData.extractMetadataKeysExpectedData);
+  });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,7 +3,7 @@
 var chai = require("chai");
 var should = chai.should();
 var utils = require("../common/models/utils.js");
-
+let utilsTestData = require("./utilsTestData");
 
 const superagentTests = {
   "put" : {
@@ -58,14 +58,14 @@ describe("utils.superagent", () => {
 describe("utils.appendSIUnitToPhysicalQuantity", () => {
 
     it("should append SI Unit to physical quantity", () => {
-      const res = utils.appendSIUnitToPhysicalQuantity(testData);
-      chai.expect(res).to.deep.equal(appendSIUnitToPhysicalQuantityExpectedData);
+      const res = utils.appendSIUnitToPhysicalQuantity(utilsTestData.testData);
+      chai.expect(res).to.deep.equal(utilsTestData.appendSIUnitToPhysicalQuantityExpectedData);
     });
 });
 
 describe("utils.extractMetadataKeys", () => {
     it("should return a array of unique keys", () => {
-      const res = utils.extractMetadataKeys([testData]);
-      chai.expect(res).to.deep.equal(extractMetadataKeysExpectedData);
+      const res = utils.extractMetadataKeys([utilsTestData.testData]);
+      chai.expect(res).to.deep.equal(utilsTestData.extractMetadataKeysExpectedData);
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,7 +34,7 @@ const superagentTests = {
 
 
 describe("utils.superagent", () => {
-    
+
   it("should return an instance of superagent", () => {
     const res = utils.superagent(superagentTests["put"]);
     res.should.not.be.empty;
@@ -55,4 +55,17 @@ describe("utils.superagent", () => {
 });
 
 
+describe("utils.appendSIUnitToPhysicalQuantity", () => {
 
+    it("should append SI Unit to physical quantity", () => {
+      const res = utils.appendSIUnitToPhysicalQuantity(testData);
+      chai.expect(res).to.deep.equal(appendSIUnitToPhysicalQuantityExpectedData);
+    });
+});
+
+describe("utils.extractMetadataKeys", () => {
+    it("should return a array of unique keys", () => {
+      const res = utils.extractMetadataKeys([testData]);
+      chai.expect(res).to.deep.equal(extractMetadataKeysExpectedData);
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -58,7 +58,7 @@ describe("utils.superagent", () => {
 describe("utils.appendSIUnitToPhysicalQuantity", () => {
 
   it("should append SI Unit to physical quantity", () => {
-    const testData = { ...utilsTestData.testData.scientificMetadata }
+    const testData = { ...utilsTestData.testData.scientificMetadata };
     utils.appendSIUnitToPhysicalQuantity(testData);
     chai.expect(testData).to.deep.equal(utilsTestData.appendSIUnitToPhysicalQuantityExpectedData);
   });

--- a/test/utilsTestData.js
+++ b/test/utilsTestData.js
@@ -1,0 +1,525 @@
+const testData = {
+    "scientificMetadata": {
+        "comment": "test2",
+        "motors": {
+            "sampx": {
+                "value": -0.03949844939218141,
+                "unit": "mm"
+            },
+            "sampy": {
+                "value": 0.003037629787175808,
+                "unit": "mm"
+            },
+            "phi": {
+                "value": 85.62724999999955,
+                "unit": "deg"
+            },
+            "zoom": 35007.46875,
+            "focus": {
+                "value": -0.2723789062500003,
+                "unit": "mm"
+            },
+            "phiz": {
+                "value": 0.18436550301217358,
+                "unit": "deg"
+            },
+            "phiy": {
+                "value": 0.21792454481296603,
+                "unit": "deg"
+            }
+        },
+        "take_snapshots": 1,
+        "shape": "2DP1",
+        "in_interleave": false,
+        "yBeam": 2124.4119215493815,
+        "wavelength": {
+            "value": 0.9789504111255567,
+            "unit": "angstrom"
+        },
+        "fileinfo": {
+            "run_number": 1,
+            "suffix": "h5",
+            "filename": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/air9-air_1_master.h5",
+            "num_files": 1,
+            "prefix": "air9-air",
+            "template": "air9-air_1_%06d.h5",
+            "archive_directory": "/mxn/groups/ispybstorage/pyarch/visitors/20170251/20190625/raw/air/air-air9/",
+            "directory": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/",
+            "process_directory": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/"
+        },
+        "in_queue": false,
+        "proposalInfo": {
+            "status": {
+                "code": "ok"
+            },
+            "Person": {
+                "personId": 216,
+                "familyName": "Carlsson",
+                "emailAddress": "ims@maxiv.lu.se",
+                "laboratoryId": 871846,
+                "login": "carlcarl",
+                "givenName": "Carla"
+            },
+            "Proposal": {
+                "code": "MX",
+                "title": "TEST for checking data handling",
+                "personId": 216,
+                "number": "20170251",
+                "proposalId": 17,
+                "type": "MX"
+            },
+            "Session": {
+                "scheduled": 0,
+                "lastUpdate": "",
+                "endDate": "2019-06-27 06:59:59",
+                "beamlineName": "CoSAXS",
+                "startDate": "2019-06-25 23:00:00",
+                "timeStamp": "",
+                "proposalName": "mx20170251",
+                "comments": "Session created by the BCM",
+                "sessionId": 1702,
+                "proposalId": 17,
+                "beamLineSetupId": 1304101,
+                "nbShifts": 3
+            },
+            "Laboratory": {
+                "laboratoryId": 871846,
+                "city": "Stockholm",
+                "name": "Swedish Museum of Natural History",
+                "address": "Box 50007\r\n104 05 Stockholm\r\n,Sweden"
+            }
+        },
+        "detector_mode": [],
+        "shutterless": true,
+        "beamShape": "ellipse",
+        "slitGapHorizontal": {
+            "value": 0.02,
+            "unit": "mm"
+        },
+        "detectorDistance": {
+            "value": 148.0342,
+            "unit": "mm"
+        },
+        "actualCenteringPosition": {
+            "sampx": {
+                "value": -0.039498,
+                "unit": "mm"
+            },
+            "sampy": {
+                "value": 0.003038,
+                "unit": "mm"
+            },
+            "phi": {
+                "value": 85.62725,
+                "unit": "deg"
+            },
+            "zoom": 35007.46875,
+            "focus": {
+                "value": -0.272379,
+                "unit": "mm"
+            },
+            "phiz": {
+                "value": 0.184366,
+                "unit": "deg"
+            },
+            "phiy": {
+                "value": 0.217925,
+                "unit": "deg"
+            }
+        },
+        "do_inducedraddam": false,
+        "xBeam": 2099.108089282656,
+        "detector_id": 3,
+        "sample_reference": {
+            "cell": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "spacegroup": 0,
+            "blSampleId": -1
+        },
+        "actualContainerBarcode": "",
+        "status": "Data collection successful",
+        "synchrotronMode": "Variable TopUp/Decay",
+        "blSampleId": -1,
+        "processing": "True",
+        "residues": 200,
+        "dark": 1,
+        "resolutionAtCorner": {
+            "value": 0.2,
+            "unit": "angstrom"
+        },
+        "slitGapVertical": 0.02,
+        "actualSampleBarcode": null,
+        "collection_id": 18389,
+        "auto_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/xds_air9-air_1_1",
+        "beamSizeAtSampleX": {
+            "value": 0.02,
+            "unit": "mm"
+        },
+        "beamSizeAtSampleY": {
+            "value": 0.02,
+            "unit": "mm"
+        },
+        "oscillation_sequence": [
+            {
+                "exposure_time": 0.1,
+                "kappaStart": -9999,
+                "start_image_number": 1,
+                "mesh_range": [],
+                "number_of_lines": 1,
+                "phiStart": -9999,
+                "number_of_images": 1,
+                "overlap": 0,
+                "start": 85.6279468749999,
+                "range": 0.1,
+                "number_of_passes": 1
+            }
+        ],
+        "EDNA_files_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/",
+        "transmission": "1.006",
+        "collection_start_time": "2019-06-26 18:01:17",
+        "anomalous": false,
+        "xds_dir": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/process/xds_air9-air_1_1",
+        "flux": 0,
+        "sessionId": 1702,
+        "experiment_type": "OSC",
+        "group_id": 18413,
+        "resolution": "1.250",
+        "skip_images": false
+    }
+}
+const appendSIUnitToPhysicalQuantityExpectedData = {
+    "scientificMetadata": {
+        "comment": "test2",
+        "motors": {
+            "sampx": {
+                "value": -0.03949844939218141,
+                "unit": "mm",
+                "valueSI": -0.00003949844939218141,
+                "unitSI": "m"
+            },
+            "sampy": {
+                "value": 0.003037629787175808,
+                "unit": "mm",
+                "valueSI": 0.000003037629787175808,
+                "unitSI": "m"
+            },
+            "phi": {
+                "value": 85.62724999999955,
+                "unit": "deg",
+                "valueSI": 1.4944774419283067,
+                "unitSI": "rad"
+            },
+            "zoom": 35007.46875,
+            "focus": {
+                "value": -0.2723789062500003,
+                "unit": "mm",
+                "valueSI": -0.00027237890625000027,
+                "unitSI": "m"
+            },
+            "phiz": {
+                "value": 0.18436550301217358,
+                "unit": "deg",
+                "valueSI": 0.003217785054657952,
+                "unitSI": "rad"
+            },
+            "phiy": {
+                "value": 0.21792454481296603,
+                "unit": "deg",
+                "valueSI": 0.0038035008278961874,
+                "unitSI": "rad"
+            }
+        },
+        "take_snapshots": 1,
+        "shape": "2DP1",
+        "in_interleave": false,
+        "yBeam": 2124.4119215493815,
+        "wavelength": {
+            "value": 0.9789504111255567,
+            "unit": "angstrom",
+            "valueSI": 9.789504111255567e-11,
+            "unitSI": "m"
+        },
+        "fileinfo": {
+            "run_number": 1,
+            "suffix": "h5",
+            "filename": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/air9-air_1_master.h5",
+            "num_files": 1,
+            "prefix": "air9-air",
+            "template": "air9-air_1_%06d.h5",
+            "archive_directory": "/mxn/groups/ispybstorage/pyarch/visitors/20170251/20190625/raw/air/air-air9/",
+            "directory": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/",
+            "process_directory": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/"
+        },
+        "in_queue": false,
+        "proposalInfo": {
+            "status": {
+                "code": "ok"
+            },
+            "Person": {
+                "personId": 216,
+                "familyName": "Carlsson",
+                "emailAddress": "ims@maxiv.lu.se",
+                "laboratoryId": 871846,
+                "login": "carlcarl",
+                "givenName": "Carla"
+            },
+            "Proposal": {
+                "code": "MX",
+                "title": "TEST for checking data handling",
+                "personId": 216,
+                "number": "20170251",
+                "proposalId": 17,
+                "type": "MX"
+            },
+            "Session": {
+                "scheduled": 0,
+                "lastUpdate": "",
+                "endDate": "2019-06-27 06:59:59",
+                "beamlineName": "CoSAXS",
+                "startDate": "2019-06-25 23:00:00",
+                "timeStamp": "",
+                "proposalName": "mx20170251",
+                "comments": "Session created by the BCM",
+                "sessionId": 1702,
+                "proposalId": 17,
+                "beamLineSetupId": 1304101,
+                "nbShifts": 3
+            },
+            "Laboratory": {
+                "laboratoryId": 871846,
+                "city": "Stockholm",
+                "name": "Swedish Museum of Natural History",
+                "address": "Box 50007\r\n104 05 Stockholm\r\n,Sweden"
+            }
+        },
+        "detector_mode": [],
+        "shutterless": true,
+        "beamShape": "ellipse",
+        "slitGapHorizontal": {
+            "value": 0.02,
+            "unit": "mm",
+            "valueSI": 0.00002,
+            "unitSI": "m"
+        },
+        "detectorDistance": {
+            "value": 148.0342,
+            "unit": "mm",
+            "valueSI": 0.1480342,
+            "unitSI": "m"
+        },
+        "actualCenteringPosition": {
+            "sampx": {
+                "value": -0.039498,
+                "unit": "mm",
+                "valueSI": -0.000039498,
+                "unitSI": "m"
+            },
+            "sampy": {
+                "value": 0.003038,
+                "unit": "mm",
+                "valueSI": 0.000003038,
+                "unitSI": "m"
+            },
+            "phi": {
+                "value": 85.62725,
+                "unit": "deg",
+                "valueSI": 1.4944774419283147,
+                "unitSI": "rad"
+            },
+            "zoom": 35007.46875,
+            "focus": {
+                "value": -0.272379,
+                "unit": "mm",
+                "valueSI": -0.000272379,
+                "unitSI": "m"
+            },
+            "phiz": {
+                "value": 0.184366,
+                "unit": "deg",
+                "valueSI": 0.0032177937287318657,
+                "unitSI": "rad"
+            },
+            "phiy": {
+                "value": 0.217925,
+                "unit": "deg",
+                "valueSI": 0.003803508772408643,
+                "unitSI": "rad"
+            }
+        },
+        "do_inducedraddam": false,
+        "xBeam": 2099.108089282656,
+        "detector_id": 3,
+        "sample_reference": {
+            "cell": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "spacegroup": 0,
+            "blSampleId": -1
+        },
+        "actualContainerBarcode": "",
+        "status": "Data collection successful",
+        "synchrotronMode": "Variable TopUp/Decay",
+        "blSampleId": -1,
+        "processing": "True",
+        "residues": 200,
+        "dark": 1,
+        "resolutionAtCorner": {
+            "value": 0.2,
+            "unit": "angstrom",
+            "valueSI": 2.0000000000000002e-11,
+            "unitSI": "m"
+        },
+        "slitGapVertical": 0.02,
+        "actualSampleBarcode": null,
+        "collection_id": 18389,
+        "auto_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/xds_air9-air_1_1",
+        "beamSizeAtSampleX": {
+            "value": 0.02,
+            "unit": "mm",
+            "valueSI": 0.00002,
+            "unitSI": "m"
+        },
+        "beamSizeAtSampleY": {
+            "value": 0.02,
+            "unit": "mm",
+            "valueSI": 0.00002,
+            "unitSI": "m"
+        },
+        "oscillation_sequence": [
+            {
+                "exposure_time": 0.1,
+                "kappaStart": -9999,
+                "start_image_number": 1,
+                "mesh_range": [],
+                "number_of_lines": 1,
+                "phiStart": -9999,
+                "number_of_images": 1,
+                "overlap": 0,
+                "start": 85.6279468749999,
+                "range": 0.1,
+                "number_of_passes": 1
+            }
+        ],
+        "EDNA_files_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/",
+        "transmission": "1.006",
+        "collection_start_time": "2019-06-26 18:01:17",
+        "anomalous": false,
+        "xds_dir": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/process/xds_air9-air_1_1",
+        "flux": 0,
+        "sessionId": 1702,
+        "experiment_type": "OSC",
+        "group_id": 18413,
+        "resolution": "1.250",
+        "skip_images": false
+    }
+};
+
+const extractMetadataKeysExpectedData = [
+  'comment',
+  'motors.sampx',
+  'motors.sampy',
+  'motors.phi',
+  'motors.zoom',
+  'motors.focus',
+  'motors.phiz',
+  'motors.phiy',
+  'take_snapshots',
+  'shape',
+  'in_interleave',
+  'yBeam',
+  'wavelength',
+  'fileinfo.run_number',
+  'fileinfo.suffix',
+  'fileinfo.filename',
+  'fileinfo.num_files',
+  'fileinfo.prefix',
+  'fileinfo.template',
+  'fileinfo.archive_directory',
+  'fileinfo.directory',
+  'fileinfo.process_directory',
+  'in_queue',
+  'proposalInfo.status.code',
+  'proposalInfo.Person.personId',
+  'proposalInfo.Person.familyName',
+  'proposalInfo.Person.emailAddress',
+  'proposalInfo.Person.laboratoryId',
+  'proposalInfo.Person.login',
+  'proposalInfo.Person.givenName',
+  'proposalInfo.Proposal.code',
+  'proposalInfo.Proposal.title',
+  'proposalInfo.Proposal.personId',
+  'proposalInfo.Proposal.number',
+  'proposalInfo.Proposal.proposalId',
+  'proposalInfo.Proposal.type',
+  'proposalInfo.Session.scheduled',
+  'proposalInfo.Session.lastUpdate',
+  'proposalInfo.Session.endDate',
+  'proposalInfo.Session.beamlineName',
+  'proposalInfo.Session.startDate',
+  'proposalInfo.Session.timeStamp',
+  'proposalInfo.Session.proposalName',
+  'proposalInfo.Session.comments',
+  'proposalInfo.Session.sessionId',
+  'proposalInfo.Session.proposalId',
+  'proposalInfo.Session.beamLineSetupId',
+  'proposalInfo.Session.nbShifts',
+  'proposalInfo.Laboratory.laboratoryId',
+  'proposalInfo.Laboratory.city',
+  'proposalInfo.Laboratory.name',
+  'proposalInfo.Laboratory.address',
+  'detector_mode',
+  'shutterless',
+  'beamShape',
+  'slitGapHorizontal',
+  'detectorDistance',
+  'actualCenteringPosition.sampx',
+  'actualCenteringPosition.sampy',
+  'actualCenteringPosition.phi',
+  'actualCenteringPosition.zoom',
+  'actualCenteringPosition.focus',
+  'actualCenteringPosition.phiz',
+  'actualCenteringPosition.phiy',
+  'do_inducedraddam',
+  'xBeam',
+  'detector_id',
+  'sample_reference.cell',
+  'sample_reference.spacegroup',
+  'sample_reference.blSampleId',
+  'actualContainerBarcode',
+  'status',
+  'synchrotronMode',
+  'blSampleId',
+  'processing',
+  'residues',
+  'dark',
+  'resolutionAtCorner',
+  'slitGapVertical',
+  'actualSampleBarcode',
+  'collection_id',
+  'auto_dir',
+  'beamSizeAtSampleX',
+  'beamSizeAtSampleY',
+  'oscillation_sequence',
+  'EDNA_files_dir',
+  'transmission',
+  'collection_start_time',
+  'anomalous',
+  'xds_dir',
+  'flux',
+  'sessionId',
+  'experiment_type',
+  'group_id',
+  'resolution',
+  'skip_images'
+]

--- a/test/utilsTestData.js
+++ b/test/utilsTestData.js
@@ -1,527 +1,525 @@
 "use strict";
 const testData = {
-    "scientificMetadata": {
-        "comment": "test2",
-        "motors": {
-            "sampx": {
-                "value": -0.03949844939218141,
-                "unit": "mm"
-            },
-            "sampy": {
-                "value": 0.003037629787175808,
-                "unit": "mm"
-            },
-            "phi": {
-                "value": 85.62724999999955,
-                "unit": "deg"
-            },
-            "zoom": 35007.46875,
-            "focus": {
-                "value": -0.2723789062500003,
-                "unit": "mm"
-            },
-            "phiz": {
-                "value": 0.18436550301217358,
-                "unit": "deg"
-            },
-            "phiy": {
-                "value": 0.21792454481296603,
-                "unit": "deg"
-            }
-        },
-        "take_snapshots": 1,
-        "shape": "2DP1",
-        "in_interleave": false,
-        "yBeam": 2124.4119215493815,
-        "wavelength": {
-            "value": 0.9789504111255567,
-            "unit": "angstrom"
-        },
-        "fileinfo": {
-            "run_number": 1,
-            "suffix": "h5",
-            "filename": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/air9-air_1_master.h5",
-            "num_files": 1,
-            "prefix": "air9-air",
-            "template": "air9-air_1_%06d.h5",
-            "archive_directory": "/mxn/groups/ispybstorage/pyarch/visitors/20170251/20190625/raw/air/air-air9/",
-            "directory": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/",
-            "process_directory": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/"
-        },
-        "in_queue": false,
-        "proposalInfo": {
-            "status": {
-                "code": "ok"
-            },
-            "Person": {
-                "personId": 216,
-                "familyName": "Carlsson",
-                "emailAddress": "ims@maxiv.lu.se",
-                "laboratoryId": 871846,
-                "login": "carlcarl",
-                "givenName": "Carla"
-            },
-            "Proposal": {
-                "code": "MX",
-                "title": "TEST for checking data handling",
-                "personId": 216,
-                "number": "20170251",
-                "proposalId": 17,
-                "type": "MX"
-            },
-            "Session": {
-                "scheduled": 0,
-                "lastUpdate": "",
-                "endDate": "2019-06-27 06:59:59",
-                "beamlineName": "CoSAXS",
-                "startDate": "2019-06-25 23:00:00",
-                "timeStamp": "",
-                "proposalName": "mx20170251",
-                "comments": "Session created by the BCM",
-                "sessionId": 1702,
-                "proposalId": 17,
-                "beamLineSetupId": 1304101,
-                "nbShifts": 3
-            },
-            "Laboratory": {
-                "laboratoryId": 871846,
-                "city": "Stockholm",
-                "name": "Swedish Museum of Natural History",
-                "address": "Box 50007\r\n104 05 Stockholm\r\n,Sweden"
-            }
-        },
-        "detector_mode": [],
-        "shutterless": true,
-        "beamShape": "ellipse",
-        "slitGapHorizontal": {
-            "value": 0.02,
-            "unit": "mm"
-        },
-        "detectorDistance": {
-            "value": 148.0342,
-            "unit": "mm"
-        },
-        "actualCenteringPosition": {
-            "sampx": {
-                "value": -0.039498,
-                "unit": "mm"
-            },
-            "sampy": {
-                "value": 0.003038,
-                "unit": "mm"
-            },
-            "phi": {
-                "value": 85.62725,
-                "unit": "deg"
-            },
-            "zoom": 35007.46875,
-            "focus": {
-                "value": -0.272379,
-                "unit": "mm"
-            },
-            "phiz": {
-                "value": 0.184366,
-                "unit": "deg"
-            },
-            "phiy": {
-                "value": 0.217925,
-                "unit": "deg"
-            }
-        },
-        "do_inducedraddam": false,
-        "xBeam": 2099.108089282656,
-        "detector_id": 3,
-        "sample_reference": {
-            "cell": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "spacegroup": 0,
-            "blSampleId": -1
-        },
-        "actualContainerBarcode": "",
-        "status": "Data collection successful",
-        "synchrotronMode": "Variable TopUp/Decay",
-        "blSampleId": -1,
-        "processing": "True",
-        "residues": 200,
-        "dark": 1,
-        "resolutionAtCorner": {
-            "value": 0.2,
-            "unit": "angstrom"
-        },
-        "slitGapVertical": 0.02,
-        "actualSampleBarcode": null,
-        "collection_id": 18389,
-        "auto_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/xds_air9-air_1_1",
-        "beamSizeAtSampleX": {
-            "value": 0.02,
-            "unit": "mm"
-        },
-        "beamSizeAtSampleY": {
-            "value": 0.02,
-            "unit": "mm"
-        },
-        "oscillation_sequence": [
-            {
-                "exposure_time": 0.1,
-                "kappaStart": -9999,
-                "start_image_number": 1,
-                "mesh_range": [],
-                "number_of_lines": 1,
-                "phiStart": -9999,
-                "number_of_images": 1,
-                "overlap": 0,
-                "start": 85.6279468749999,
-                "range": 0.1,
-                "number_of_passes": 1
-            }
-        ],
-        "EDNA_files_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/",
-        "transmission": "1.006",
-        "collection_start_time": "2019-06-26 18:01:17",
-        "anomalous": false,
-        "xds_dir": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/process/xds_air9-air_1_1",
-        "flux": 0,
+  "scientificMetadata": {
+    "comment": "test2",
+    "motors": {
+      "sampx": {
+        "value": -0.03949844939218141,
+        "unit": "mm"
+      },
+      "sampy": {
+        "value": 0.003037629787175808,
+        "unit": "mm"
+      },
+      "phi": {
+        "value": 85.62724999999955,
+        "unit": "deg"
+      },
+      "zoom": 35007.46875,
+      "focus": {
+        "value": -0.2723789062500003,
+        "unit": "mm"
+      },
+      "phiz": {
+        "value": 0.18436550301217358,
+        "unit": "deg"
+      },
+      "phiy": {
+        "value": 0.21792454481296603,
+        "unit": "deg"
+      }
+    },
+    "take_snapshots": 1,
+    "shape": "2DP1",
+    "in_interleave": false,
+    "yBeam": 2124.4119215493815,
+    "wavelength": {
+      "value": 0.9789504111255567,
+      "unit": "angstrom"
+    },
+    "fileinfo": {
+      "run_number": 1,
+      "suffix": "h5",
+      "filename": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/air9-air_1_master.h5",
+      "num_files": 1,
+      "prefix": "air9-air",
+      "template": "air9-air_1_%06d.h5",
+      "archive_directory": "/mxn/groups/ispybstorage/pyarch/visitors/20170251/20190625/raw/air/air-air9/",
+      "directory": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/",
+      "process_directory": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/"
+    },
+    "in_queue": false,
+    "proposalInfo": {
+      "status": {
+        "code": "ok"
+      },
+      "Person": {
+        "personId": 216,
+        "familyName": "Carlsson",
+        "emailAddress": "ims@maxiv.lu.se",
+        "laboratoryId": 871846,
+        "login": "carlcarl",
+        "givenName": "Carla"
+      },
+      "Proposal": {
+        "code": "MX",
+        "title": "TEST for checking data handling",
+        "personId": 216,
+        "number": "20170251",
+        "proposalId": 17,
+        "type": "MX"
+      },
+      "Session": {
+        "scheduled": 0,
+        "lastUpdate": "",
+        "endDate": "2019-06-27 06:59:59",
+        "beamlineName": "CoSAXS",
+        "startDate": "2019-06-25 23:00:00",
+        "timeStamp": "",
+        "proposalName": "mx20170251",
+        "comments": "Session created by the BCM",
         "sessionId": 1702,
-        "experiment_type": "OSC",
-        "group_id": 18413,
-        "resolution": "1.250",
-        "skip_images": false
-    }
+        "proposalId": 17,
+        "beamLineSetupId": 1304101,
+        "nbShifts": 3
+      },
+      "Laboratory": {
+        "laboratoryId": 871846,
+        "city": "Stockholm",
+        "name": "Swedish Museum of Natural History",
+        "address": "Box 50007\r\n104 05 Stockholm\r\n,Sweden"
+      }
+    },
+    "detector_mode": [],
+    "shutterless": true,
+    "beamShape": "ellipse",
+    "slitGapHorizontal": {
+      "value": 0.02,
+      "unit": "mm"
+    },
+    "detectorDistance": {
+      "value": 148.0342,
+      "unit": "mm"
+    },
+    "actualCenteringPosition": {
+      "sampx": {
+        "value": -0.039498,
+        "unit": "mm"
+      },
+      "sampy": {
+        "value": 0.003038,
+        "unit": "mm"
+      },
+      "phi": {
+        "value": 85.62725,
+        "unit": "deg"
+      },
+      "zoom": 35007.46875,
+      "focus": {
+        "value": -0.272379,
+        "unit": "mm"
+      },
+      "phiz": {
+        "value": 0.184366,
+        "unit": "deg"
+      },
+      "phiy": {
+        "value": 0.217925,
+        "unit": "deg"
+      }
+    },
+    "do_inducedraddam": false,
+    "xBeam": 2099.108089282656,
+    "detector_id": 3,
+    "sample_reference": {
+      "cell": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "spacegroup": 0,
+      "blSampleId": -1
+    },
+    "actualContainerBarcode": "",
+    "status": "Data collection successful",
+    "synchrotronMode": "Variable TopUp/Decay",
+    "blSampleId": -1,
+    "processing": "True",
+    "residues": 200,
+    "dark": 1,
+    "resolutionAtCorner": {
+      "value": 0.2,
+      "unit": "angstrom"
+    },
+    "slitGapVertical": 0.02,
+    "actualSampleBarcode": null,
+    "collection_id": 18389,
+    "auto_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/xds_air9-air_1_1",
+    "beamSizeAtSampleX": {
+      "value": 0.02,
+      "unit": "mm"
+    },
+    "beamSizeAtSampleY": {
+      "value": 0.02,
+      "unit": "mm"
+    },
+    "oscillation_sequence": [
+      {
+        "exposure_time": 0.1,
+        "kappaStart": -9999,
+        "start_image_number": 1,
+        "mesh_range": [],
+        "number_of_lines": 1,
+        "phiStart": -9999,
+        "number_of_images": 1,
+        "overlap": 0,
+        "start": 85.6279468749999,
+        "range": 0.1,
+        "number_of_passes": 1
+      }
+    ],
+    "EDNA_files_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/",
+    "transmission": "1.006",
+    "collection_start_time": "2019-06-26 18:01:17",
+    "anomalous": false,
+    "xds_dir": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/process/xds_air9-air_1_1",
+    "flux": 0,
+    "sessionId": 1702,
+    "experiment_type": "OSC",
+    "group_id": 18413,
+    "resolution": "1.250",
+    "skip_images": false
+  }
 };
 const appendSIUnitToPhysicalQuantityExpectedData = {
-    "scientificMetadata": {
-        "comment": "test2",
-        "motors": {
-            "sampx": {
-                "value": -0.03949844939218141,
-                "unit": "mm",
-                "valueSI": -0.00003949844939218141,
-                "unitSI": "m"
-            },
-            "sampy": {
-                "value": 0.003037629787175808,
-                "unit": "mm",
-                "valueSI": 0.000003037629787175808,
-                "unitSI": "m"
-            },
-            "phi": {
-                "value": 85.62724999999955,
-                "unit": "deg",
-                "valueSI": 1.4944774419283067,
-                "unitSI": "rad"
-            },
-            "zoom": 35007.46875,
-            "focus": {
-                "value": -0.2723789062500003,
-                "unit": "mm",
-                "valueSI": -0.00027237890625000027,
-                "unitSI": "m"
-            },
-            "phiz": {
-                "value": 0.18436550301217358,
-                "unit": "deg",
-                "valueSI": 0.003217785054657952,
-                "unitSI": "rad"
-            },
-            "phiy": {
-                "value": 0.21792454481296603,
-                "unit": "deg",
-                "valueSI": 0.0038035008278961874,
-                "unitSI": "rad"
-            }
-        },
-        "take_snapshots": 1,
-        "shape": "2DP1",
-        "in_interleave": false,
-        "yBeam": 2124.4119215493815,
-        "wavelength": {
-            "value": 0.9789504111255567,
-            "unit": "angstrom",
-            "valueSI": 9.789504111255567e-11,
-            "unitSI": "m"
-        },
-        "fileinfo": {
-            "run_number": 1,
-            "suffix": "h5",
-            "filename": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/air9-air_1_master.h5",
-            "num_files": 1,
-            "prefix": "air9-air",
-            "template": "air9-air_1_%06d.h5",
-            "archive_directory": "/mxn/groups/ispybstorage/pyarch/visitors/20170251/20190625/raw/air/air-air9/",
-            "directory": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/",
-            "process_directory": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/"
-        },
-        "in_queue": false,
-        "proposalInfo": {
-            "status": {
-                "code": "ok"
-            },
-            "Person": {
-                "personId": 216,
-                "familyName": "Carlsson",
-                "emailAddress": "ims@maxiv.lu.se",
-                "laboratoryId": 871846,
-                "login": "carlcarl",
-                "givenName": "Carla"
-            },
-            "Proposal": {
-                "code": "MX",
-                "title": "TEST for checking data handling",
-                "personId": 216,
-                "number": "20170251",
-                "proposalId": 17,
-                "type": "MX"
-            },
-            "Session": {
-                "scheduled": 0,
-                "lastUpdate": "",
-                "endDate": "2019-06-27 06:59:59",
-                "beamlineName": "CoSAXS",
-                "startDate": "2019-06-25 23:00:00",
-                "timeStamp": "",
-                "proposalName": "mx20170251",
-                "comments": "Session created by the BCM",
-                "sessionId": 1702,
-                "proposalId": 17,
-                "beamLineSetupId": 1304101,
-                "nbShifts": 3
-            },
-            "Laboratory": {
-                "laboratoryId": 871846,
-                "city": "Stockholm",
-                "name": "Swedish Museum of Natural History",
-                "address": "Box 50007\r\n104 05 Stockholm\r\n,Sweden"
-            }
-        },
-        "detector_mode": [],
-        "shutterless": true,
-        "beamShape": "ellipse",
-        "slitGapHorizontal": {
-            "value": 0.02,
-            "unit": "mm",
-            "valueSI": 0.00002,
-            "unitSI": "m"
-        },
-        "detectorDistance": {
-            "value": 148.0342,
-            "unit": "mm",
-            "valueSI": 0.1480342,
-            "unitSI": "m"
-        },
-        "actualCenteringPosition": {
-            "sampx": {
-                "value": -0.039498,
-                "unit": "mm",
-                "valueSI": -0.000039498,
-                "unitSI": "m"
-            },
-            "sampy": {
-                "value": 0.003038,
-                "unit": "mm",
-                "valueSI": 0.000003038,
-                "unitSI": "m"
-            },
-            "phi": {
-                "value": 85.62725,
-                "unit": "deg",
-                "valueSI": 1.4944774419283147,
-                "unitSI": "rad"
-            },
-            "zoom": 35007.46875,
-            "focus": {
-                "value": -0.272379,
-                "unit": "mm",
-                "valueSI": -0.000272379,
-                "unitSI": "m"
-            },
-            "phiz": {
-                "value": 0.184366,
-                "unit": "deg",
-                "valueSI": 0.0032177937287318657,
-                "unitSI": "rad"
-            },
-            "phiy": {
-                "value": 0.217925,
-                "unit": "deg",
-                "valueSI": 0.003803508772408643,
-                "unitSI": "rad"
-            }
-        },
-        "do_inducedraddam": false,
-        "xBeam": 2099.108089282656,
-        "detector_id": 3,
-        "sample_reference": {
-            "cell": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "spacegroup": 0,
-            "blSampleId": -1
-        },
-        "actualContainerBarcode": "",
-        "status": "Data collection successful",
-        "synchrotronMode": "Variable TopUp/Decay",
-        "blSampleId": -1,
-        "processing": "True",
-        "residues": 200,
-        "dark": 1,
-        "resolutionAtCorner": {
-            "value": 0.2,
-            "unit": "angstrom",
-            "valueSI": 2.0000000000000002e-11,
-            "unitSI": "m"
-        },
-        "slitGapVertical": 0.02,
-        "actualSampleBarcode": null,
-        "collection_id": 18389,
-        "auto_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/xds_air9-air_1_1",
-        "beamSizeAtSampleX": {
-            "value": 0.02,
-            "unit": "mm",
-            "valueSI": 0.00002,
-            "unitSI": "m"
-        },
-        "beamSizeAtSampleY": {
-            "value": 0.02,
-            "unit": "mm",
-            "valueSI": 0.00002,
-            "unitSI": "m"
-        },
-        "oscillation_sequence": [
-            {
-                "exposure_time": 0.1,
-                "kappaStart": -9999,
-                "start_image_number": 1,
-                "mesh_range": [],
-                "number_of_lines": 1,
-                "phiStart": -9999,
-                "number_of_images": 1,
-                "overlap": 0,
-                "start": 85.6279468749999,
-                "range": 0.1,
-                "number_of_passes": 1
-            }
-        ],
-        "EDNA_files_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/",
-        "transmission": "1.006",
-        "collection_start_time": "2019-06-26 18:01:17",
-        "anomalous": false,
-        "xds_dir": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/process/xds_air9-air_1_1",
-        "flux": 0,
-        "sessionId": 1702,
-        "experiment_type": "OSC",
-        "group_id": 18413,
-        "resolution": "1.250",
-        "skip_images": false
+  "comment": "test2",
+  "motors": {
+    "sampx": {
+      "value": -0.03949844939218141,
+      "unit": "mm",
+      "valueSI": -0.00003949844939218141,
+      "unitSI": "m"
+    },
+    "sampy": {
+      "value": 0.003037629787175808,
+      "unit": "mm",
+      "valueSI": 0.000003037629787175808,
+      "unitSI": "m"
+    },
+    "phi": {
+      "value": 85.62724999999955,
+      "unit": "deg",
+      "valueSI": 1.4944774419283067,
+      "unitSI": "rad"
+    },
+    "zoom": 35007.46875,
+    "focus": {
+      "value": -0.2723789062500003,
+      "unit": "mm",
+      "valueSI": -0.00027237890625000027,
+      "unitSI": "m"
+    },
+    "phiz": {
+      "value": 0.18436550301217358,
+      "unit": "deg",
+      "valueSI": 0.003217785054657952,
+      "unitSI": "rad"
+    },
+    "phiy": {
+      "value": 0.21792454481296603,
+      "unit": "deg",
+      "valueSI": 0.0038035008278961874,
+      "unitSI": "rad"
     }
+  },
+  "take_snapshots": 1,
+  "shape": "2DP1",
+  "in_interleave": false,
+  "yBeam": 2124.4119215493815,
+  "wavelength": {
+    "value": 0.9789504111255567,
+    "unit": "angstrom",
+    "valueSI": 9.789504111255567e-11,
+    "unitSI": "m"
+  },
+  "fileinfo": {
+    "run_number": 1,
+    "suffix": "h5",
+    "filename": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/air9-air_1_master.h5",
+    "num_files": 1,
+    "prefix": "air9-air",
+    "template": "air9-air_1_%06d.h5",
+    "archive_directory": "/mxn/groups/ispybstorage/pyarch/visitors/20170251/20190625/raw/air/air-air9/",
+    "directory": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/",
+    "process_directory": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/"
+  },
+  "in_queue": false,
+  "proposalInfo": {
+    "status": {
+      "code": "ok"
+    },
+    "Person": {
+      "personId": 216,
+      "familyName": "Carlsson",
+      "emailAddress": "ims@maxiv.lu.se",
+      "laboratoryId": 871846,
+      "login": "carlcarl",
+      "givenName": "Carla"
+    },
+    "Proposal": {
+      "code": "MX",
+      "title": "TEST for checking data handling",
+      "personId": 216,
+      "number": "20170251",
+      "proposalId": 17,
+      "type": "MX"
+    },
+    "Session": {
+      "scheduled": 0,
+      "lastUpdate": "",
+      "endDate": "2019-06-27 06:59:59",
+      "beamlineName": "CoSAXS",
+      "startDate": "2019-06-25 23:00:00",
+      "timeStamp": "",
+      "proposalName": "mx20170251",
+      "comments": "Session created by the BCM",
+      "sessionId": 1702,
+      "proposalId": 17,
+      "beamLineSetupId": 1304101,
+      "nbShifts": 3
+    },
+    "Laboratory": {
+      "laboratoryId": 871846,
+      "city": "Stockholm",
+      "name": "Swedish Museum of Natural History",
+      "address": "Box 50007\r\n104 05 Stockholm\r\n,Sweden"
+    }
+  },
+  "detector_mode": [],
+  "shutterless": true,
+  "beamShape": "ellipse",
+  "slitGapHorizontal": {
+    "value": 0.02,
+    "unit": "mm",
+    "valueSI": 0.00002,
+    "unitSI": "m"
+  },
+  "detectorDistance": {
+    "value": 148.0342,
+    "unit": "mm",
+    "valueSI": 0.1480342,
+    "unitSI": "m"
+  },
+  "actualCenteringPosition": {
+    "sampx": {
+      "value": -0.039498,
+      "unit": "mm",
+      "valueSI": -0.000039498,
+      "unitSI": "m"
+    },
+    "sampy": {
+      "value": 0.003038,
+      "unit": "mm",
+      "valueSI": 0.000003038,
+      "unitSI": "m"
+    },
+    "phi": {
+      "value": 85.62725,
+      "unit": "deg",
+      "valueSI": 1.4944774419283147,
+      "unitSI": "rad"
+    },
+    "zoom": 35007.46875,
+    "focus": {
+      "value": -0.272379,
+      "unit": "mm",
+      "valueSI": -0.000272379,
+      "unitSI": "m"
+    },
+    "phiz": {
+      "value": 0.184366,
+      "unit": "deg",
+      "valueSI": 0.0032177937287318657,
+      "unitSI": "rad"
+    },
+    "phiy": {
+      "value": 0.217925,
+      "unit": "deg",
+      "valueSI": 0.003803508772408643,
+      "unitSI": "rad"
+    }
+  },
+  "do_inducedraddam": false,
+  "xBeam": 2099.108089282656,
+  "detector_id": 3,
+  "sample_reference": {
+    "cell": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "spacegroup": 0,
+    "blSampleId": -1
+  },
+  "actualContainerBarcode": "",
+  "status": "Data collection successful",
+  "synchrotronMode": "Variable TopUp/Decay",
+  "blSampleId": -1,
+  "processing": "True",
+  "residues": 200,
+  "dark": 1,
+  "resolutionAtCorner": {
+    "value": 0.2,
+    "unit": "angstrom",
+    "valueSI": 2.0000000000000002e-11,
+    "unitSI": "m"
+  },
+  "slitGapVertical": 0.02,
+  "actualSampleBarcode": null,
+  "collection_id": 18389,
+  "auto_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/xds_air9-air_1_1",
+  "beamSizeAtSampleX": {
+    "value": 0.02,
+    "unit": "mm",
+    "valueSI": 0.00002,
+    "unitSI": "m"
+  },
+  "beamSizeAtSampleY": {
+    "value": 0.02,
+    "unit": "mm",
+    "valueSI": 0.00002,
+    "unitSI": "m"
+  },
+  "oscillation_sequence": [
+    {
+      "exposure_time": 0.1,
+      "kappaStart": -9999,
+      "start_image_number": 1,
+      "mesh_range": [],
+      "number_of_lines": 1,
+      "phiStart": -9999,
+      "number_of_images": 1,
+      "overlap": 0,
+      "start": 85.6279468749999,
+      "range": 0.1,
+      "number_of_passes": 1
+    }
+  ],
+  "EDNA_files_dir": "/data/visitors/cosaxs/20170251/20190625/process/air/air-air9/",
+  "transmission": "1.006",
+  "collection_start_time": "2019-06-26 18:01:17",
+  "anomalous": false,
+  "xds_dir": "/data/visitors/cosaxs/20170251/20190625/raw/air/air-air9/process/xds_air9-air_1_1",
+  "flux": 0,
+  "sessionId": 1702,
+  "experiment_type": "OSC",
+  "group_id": 18413,
+  "resolution": "1.250",
+  "skip_images": false
 };
 
 const extractMetadataKeysExpectedData = [
-  'comment',
-  'motors.sampx',
-  'motors.sampy',
-  'motors.phi',
-  'motors.zoom',
-  'motors.focus',
-  'motors.phiz',
-  'motors.phiy',
-  'take_snapshots',
-  'shape',
-  'in_interleave',
-  'yBeam',
-  'wavelength',
-  'fileinfo.run_number',
-  'fileinfo.suffix',
-  'fileinfo.filename',
-  'fileinfo.num_files',
-  'fileinfo.prefix',
-  'fileinfo.template',
-  'fileinfo.archive_directory',
-  'fileinfo.directory',
-  'fileinfo.process_directory',
-  'in_queue',
-  'proposalInfo.status.code',
-  'proposalInfo.Person.personId',
-  'proposalInfo.Person.familyName',
-  'proposalInfo.Person.emailAddress',
-  'proposalInfo.Person.laboratoryId',
-  'proposalInfo.Person.login',
-  'proposalInfo.Person.givenName',
-  'proposalInfo.Proposal.code',
-  'proposalInfo.Proposal.title',
-  'proposalInfo.Proposal.personId',
-  'proposalInfo.Proposal.number',
-  'proposalInfo.Proposal.proposalId',
-  'proposalInfo.Proposal.type',
-  'proposalInfo.Session.scheduled',
-  'proposalInfo.Session.lastUpdate',
-  'proposalInfo.Session.endDate',
-  'proposalInfo.Session.beamlineName',
-  'proposalInfo.Session.startDate',
-  'proposalInfo.Session.timeStamp',
-  'proposalInfo.Session.proposalName',
-  'proposalInfo.Session.comments',
-  'proposalInfo.Session.sessionId',
-  'proposalInfo.Session.proposalId',
-  'proposalInfo.Session.beamLineSetupId',
-  'proposalInfo.Session.nbShifts',
-  'proposalInfo.Laboratory.laboratoryId',
-  'proposalInfo.Laboratory.city',
-  'proposalInfo.Laboratory.name',
-  'proposalInfo.Laboratory.address',
-  'detector_mode',
-  'shutterless',
-  'beamShape',
-  'slitGapHorizontal',
-  'detectorDistance',
-  'actualCenteringPosition.sampx',
-  'actualCenteringPosition.sampy',
-  'actualCenteringPosition.phi',
-  'actualCenteringPosition.zoom',
-  'actualCenteringPosition.focus',
-  'actualCenteringPosition.phiz',
-  'actualCenteringPosition.phiy',
-  'do_inducedraddam',
-  'xBeam',
-  'detector_id',
-  'sample_reference.cell',
-  'sample_reference.spacegroup',
-  'sample_reference.blSampleId',
-  'actualContainerBarcode',
-  'status',
-  'synchrotronMode',
-  'blSampleId',
-  'processing',
-  'residues',
-  'dark',
-  'resolutionAtCorner',
-  'slitGapVertical',
-  'actualSampleBarcode',
-  'collection_id',
-  'auto_dir',
-  'beamSizeAtSampleX',
-  'beamSizeAtSampleY',
-  'oscillation_sequence',
-  'EDNA_files_dir',
-  'transmission',
-  'collection_start_time',
-  'anomalous',
-  'xds_dir',
-  'flux',
-  'sessionId',
-  'experiment_type',
-  'group_id',
-  'resolution',
-  'skip_images'
+  "comment",
+  "motors.sampx",
+  "motors.sampy",
+  "motors.phi",
+  "motors.zoom",
+  "motors.focus",
+  "motors.phiz",
+  "motors.phiy",
+  "take_snapshots",
+  "shape",
+  "in_interleave",
+  "yBeam",
+  "wavelength",
+  "fileinfo.run_number",
+  "fileinfo.suffix",
+  "fileinfo.filename",
+  "fileinfo.num_files",
+  "fileinfo.prefix",
+  "fileinfo.template",
+  "fileinfo.archive_directory",
+  "fileinfo.directory",
+  "fileinfo.process_directory",
+  "in_queue",
+  "proposalInfo.status.code",
+  "proposalInfo.Person.personId",
+  "proposalInfo.Person.familyName",
+  "proposalInfo.Person.emailAddress",
+  "proposalInfo.Person.laboratoryId",
+  "proposalInfo.Person.login",
+  "proposalInfo.Person.givenName",
+  "proposalInfo.Proposal.code",
+  "proposalInfo.Proposal.title",
+  "proposalInfo.Proposal.personId",
+  "proposalInfo.Proposal.number",
+  "proposalInfo.Proposal.proposalId",
+  "proposalInfo.Proposal.type",
+  "proposalInfo.Session.scheduled",
+  "proposalInfo.Session.lastUpdate",
+  "proposalInfo.Session.endDate",
+  "proposalInfo.Session.beamlineName",
+  "proposalInfo.Session.startDate",
+  "proposalInfo.Session.timeStamp",
+  "proposalInfo.Session.proposalName",
+  "proposalInfo.Session.comments",
+  "proposalInfo.Session.sessionId",
+  "proposalInfo.Session.proposalId",
+  "proposalInfo.Session.beamLineSetupId",
+  "proposalInfo.Session.nbShifts",
+  "proposalInfo.Laboratory.laboratoryId",
+  "proposalInfo.Laboratory.city",
+  "proposalInfo.Laboratory.name",
+  "proposalInfo.Laboratory.address",
+  "detector_mode",
+  "shutterless",
+  "beamShape",
+  "slitGapHorizontal",
+  "detectorDistance",
+  "actualCenteringPosition.sampx",
+  "actualCenteringPosition.sampy",
+  "actualCenteringPosition.phi",
+  "actualCenteringPosition.zoom",
+  "actualCenteringPosition.focus",
+  "actualCenteringPosition.phiz",
+  "actualCenteringPosition.phiy",
+  "do_inducedraddam",
+  "xBeam",
+  "detector_id",
+  "sample_reference.cell",
+  "sample_reference.spacegroup",
+  "sample_reference.blSampleId",
+  "actualContainerBarcode",
+  "status",
+  "synchrotronMode",
+  "blSampleId",
+  "processing",
+  "residues",
+  "dark",
+  "resolutionAtCorner",
+  "slitGapVertical",
+  "actualSampleBarcode",
+  "collection_id",
+  "auto_dir",
+  "beamSizeAtSampleX",
+  "beamSizeAtSampleY",
+  "oscillation_sequence",
+  "EDNA_files_dir",
+  "transmission",
+  "collection_start_time",
+  "anomalous",
+  "xds_dir",
+  "flux",
+  "sessionId",
+  "experiment_type",
+  "group_id",
+  "resolution",
+  "skip_images"
 ];
 module.exports = { testData, extractMetadataKeysExpectedData, appendSIUnitToPhysicalQuantityExpectedData };

--- a/test/utilsTestData.js
+++ b/test/utilsTestData.js
@@ -1,3 +1,4 @@
+"use strict";
 const testData = {
     "scientificMetadata": {
         "comment": "test2",
@@ -192,7 +193,7 @@ const testData = {
         "resolution": "1.250",
         "skip_images": false
     }
-}
+};
 const appendSIUnitToPhysicalQuantityExpectedData = {
     "scientificMetadata": {
         "comment": "test2",
@@ -522,4 +523,5 @@ const extractMetadataKeysExpectedData = [
   'group_id',
   'resolution',
   'skip_images'
-]
+];
+module.exports = { testData, extractMetadataKeysExpectedData, appendSIUnitToPhysicalQuantityExpectedData };


### PR DESCRIPTION
## Description

Searching/filtering of nested metadata.

## Motivation
Since the frontend has support for nested metadata, it requires some modifications in the backend to allow searching/filtering of nested metadata. The support for flat metadata is still the same.
## Fixes:
- Implemented a function to extract flat/nested metadata keys
- Implemented a function to append SI unit and value to physical quantity
## Changes:
With these fixes above the user can now using nested metadata keys on "Add condition". Nested metadata keys have this structure: `parentKey.childKey.granchildKey...`
![Screenshot 2021-06-08 at 09 14 45](https://user-images.githubusercontent.com/17545757/121140351-073c9000-c83a-11eb-8bea-7bb25bcdbe4c.png)

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?


