### PR TITLE
V u

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -151,18 +151,6 @@ module.exports = function(Dataset) {
     next();
   });
 
-  Dataset.beforeRemote("prototype.patchAttributes", function (
-    ctx,
-    unused,
-    next
-  ) {
-    if ("scientificMetadata" in ctx.args.data) {
-      const { scientificMetadata } = ctx.args.data;
-      utils.appendSIUnitToPhysicalQuantity(scientificMetadata);
-    }
-    next();
-  });
-
   Dataset.afterRemote("fullquery", function (ctx, someCollections, next) {
     if (ctx.args.fields.scientific) {
       const {
@@ -422,6 +410,12 @@ module.exports = function(Dataset) {
           );
         }
       });
+
+      // convert scientificMetadata value to SI
+      if (ctx.instance.scientificMetadata) {
+        const { scientificMetadata } = ctx.instance;
+        utils.appendSIUnitToPhysicalQuantity(scientificMetadata);
+      }
     } else {
       // update case
       utils.keepHistory(ctx, next);

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -371,11 +371,11 @@ exports.convertToRequestedUnit = (value, currentUnit, requestedUnit) => {
 exports.appendSIUnitToPhysicalQuantity = (object) => {
   Object.keys(object).forEach((key) => {
     const value = object[key];
-    if (value && value.unit) {
+    if (value && (value.unit || value.u)) {
       const {
         valueSI,
         unitSI
-      } = exports.convertToSI(value.value, value.unit);
+      } = exports.convertToSI(value.value || value.v, value.unit || value.u);
       object[key] = {
         ...value,
         valueSI,
@@ -390,7 +390,7 @@ exports.appendSIUnitToPhysicalQuantity = (object) => {
 };
 /**Check if input is object or a physical quantity */
 const isObject = (x) => {
-  if(x && typeof x === "object" && (!Array.isArray(x) && (!x.unit && x.unit !== ""))){
+  if(x && typeof x === "object" && (!Array.isArray(x) && (!x.unit && x.unit !== "") && (!x.u && x.u !== ""))){
     return true;
   }
   return false;

--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -348,9 +348,8 @@ exports.sendMail = (to, cc, subjectText, mailText, e, next) => {
 
 exports.convertToSI = (value, unit) => {
   try {
-    const quantity = math.unit(value, unit).toSI().toString();
-    const [convertedValue, convertedUnit] = quantity.split(" ");
-    return { valueSI: Number(convertedValue), unitSI: convertedUnit };
+    const quantity = math.unit(value, unit).toSI().toJSON();
+    return { valueSI: Number(quantity.value), unitSI: quantity.unit };
   } catch (error) {
     console.log(error);
     return { valueSI: value, unitSI: unit };
@@ -390,7 +389,7 @@ exports.appendSIUnitToPhysicalQuantity = (object) => {
 };
 /**Check if input is object or a physical quantity */
 const isObject = (x) => {
-  if(x && typeof x === "object" && (!Array.isArray(x) && (!x.unit && x.unit !== "") && (!x.u && x.u !== ""))){
+  if(x && typeof x === "object" && (!Array.isArray(x) && (!x.unit && x.unit !== "")&& (!x.u && x.u !== ""))){
     return true;
   }
   return false;

--- a/test/utilsTestData.js
+++ b/test/utilsTestData.js
@@ -27,6 +27,10 @@ const testData = {
       "phiy": {
         "value": 0.21792454481296603,
         "unit": "deg"
+      },
+      "en": {
+        "v": 9998,
+        "u": "eV"
       }
     },
     "take_snapshots": 1,
@@ -233,6 +237,12 @@ const appendSIUnitToPhysicalQuantityExpectedData = {
       "unit": "deg",
       "valueSI": 0.0038035008278961874,
       "unitSI": "rad"
+    },
+    "en": {
+      "v": 9998,
+      "u": "eV",
+      "valueSI": 1.601856129687e-15,
+      "unitSI": "(kg m^2) / s^2"
     }
   },
   "take_snapshots": 1,
@@ -433,6 +443,7 @@ const extractMetadataKeysExpectedData = [
   "motors.focus",
   "motors.phiz",
   "motors.phiy",
+  "motors.en",
   "take_snapshots",
   "shape",
   "in_interleave",


### PR DESCRIPTION
## Description

Conversion to standard unit to take place during dataset save, rather than patch. V and U as possible keys for scientific metadata value and unit
## Motivation

Conversion is needed also when dataset is created

## Fixes:

* instead of converting SI conversion to string and split, it converts to json and access fields.

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
