### PR TITLE
Update consumer to use fanout

### DIFF
--- a/server/boot/startRabbitMqConsumer.js
+++ b/server/boot/startRabbitMqConsumer.js
@@ -1,125 +1,121 @@
 "use strict";
-const amqp = require("amqplib/callback_api");
+const amqp = require("amqplib");
 const config = require("../config.local");
 const logger = require("../../common/logger");
 const utils = require("../../common/models/utils");
 
-module.exports = function (app) {
+module.exports = async function (app) {
   const Proposal = app.models.Proposal;
   let connectionDetails;
-  const startConsumer = (connection) => {
-    connection.createChannel(function (error, channel) {
-      if (error) {
-        logger.logError(error.message, {
-          location: "connection.createChannel",
-          connection
-        });
-      } else {
-        const queue = config.rabbitmq.queue;
-        channel.assertQueue(queue, {
-          durable: true
-        });
-        channel.prefetch(1);
 
-        logger.logInfo("RABBITMQ Waiting for messages", {
-          queue
-        });
+  const startConsumer = async (connection) => {
+    try {
+      const channel = await connection.createChannel();
+      await channel.assertExchange("useroffice.fanout", "fanout", { durable: true });
+      const queueName = await channel.assertQueue("", { exclusive: true });
+      await channel.bindQueue(queueName.queue, "useroffice.fanout", "");
+      channel.prefetch(1);
 
-        // instantiate the consumer
-        channel.consume(
-          queue,
-          async function (msg) {
-            try {
-              const payload = JSON.parse(msg.content);
-              logger.logInfo("Message properties",JSON.stringify(msg.properties).toString());
-              logger.logInfo("Message body",JSON.stringify(payload).toString());
-              switch (msg.properties.type) {
-              case "PROPOSAL_ACCEPTED": {
-                /* 
-                  from useroffice code, courtesy of Jekabs
-                  msgJSON
-                    content -> payload
-                      proposalId
-                      shortCode
-                      title
-                      members: [
-                        {
+      logger.logInfo("RABBITMQ Waiting for messages", {
+        queue: queueName.queue
+      });
+
+      await channel.consume(queueName.queue, async (msg) => {
+        try {
+          const payload = JSON.parse(msg.content);
+          logger.logInfo("Message properties", JSON.stringify(msg.properties).toString());
+          logger.logInfo("Message body", JSON.stringify(payload).toString());
+          switch (msg.properties.type) {
+          case "PROPOSAL_ACCEPTED": {
+            /* 
+                    from useroffice code, courtesy of Jekabs
+                    msgJSON
+                      content -> payload
+                        proposalId
+                        shortCode
+                        title
+                        members: [
+                          {
+                            firstName
+                            lastName
+                            email
+                          }
+                        ]
+                        proposer: {
                           firstName
                           lastName
                           email
                         }
-                      ]
-                      proposer: {
-                        firstName
-                        lastName
-                        email
-                      }
-                    properties
-                      type -> event type
-                */  
-                logger.logInfo(
-                  "RabbitMq message for PROPOSAL_ACCEPTED",
-                  {
-                    message: payload
-                  }
-                );
-                /*
-                  We need to refactor proposal fields to match scicat
+                      properties
+                        type -> event type
                   */
-                let proposalData = {
-                  "proposalId" : payload.shortCode,
-                  "title" : payload.title,
-                  "pi_email" : payload.proposer.email,
-                  "pi_firstname" : payload.proposer.firstName,
-                  "pi_lastname" : payload.proposer.lastName,
-                  "email" : payload.proposer.email,
-                  "firstname" : payload.proposer.firstName,
-                  "lastname" : payload.proposer.lastName,
-                  "abstract" : payload.asbtract,
-                  "ownerGroup" : "ess",
-                  "createdBy" : "proposalIngestor"
-                };
-                logger.logInfo(
-                  "SciCat proposal data",
-                  {
-                    proposalData: proposalData 
-                  }
-                );
-                  
-                Proposal.replaceOrCreate(proposalData, (error, proposalInstance) => {
-                  if (error) {
-                    logger.logError(error.message, {
-                      location: "Proposal.replaceOrCreate"
-                    });
-                  } else {
-                    if (proposalInstance) {
-                      logger.logInfo("Proposal was created/updated",{
-                        proposalId: proposalData.proposalId
-                      });
-                    }
-                  }
+            logger.logInfo(
+              "RabbitMq message for PROPOSAL_ACCEPTED",
+              {
+                message: payload
+              }
+            );
+            /*
+                    We need to refactor proposal fields to match scicat
+                    */
+            let proposalData = {
+              "proposalId": payload.shortCode,
+              "title": payload.title,
+              "pi_email": payload.proposer.email,
+              "pi_firstname": payload.proposer.firstName,
+              "pi_lastname": payload.proposer.lastName,
+              "email": payload.proposer.email,
+              "firstname": payload.proposer.firstName,
+              "lastname": payload.proposer.lastName,
+              "abstract": payload.asbtract,
+              "ownerGroup": "ess",
+              "createdBy": "proposalIngestor"
+            };
+            logger.logInfo(
+              "SciCat proposal data",
+              {
+                proposalData: proposalData
+              }
+            );
+
+            Proposal.replaceOrCreate(proposalData, (error, proposalInstance) => {
+              if (error) {
+                logger.logError(error.message, {
+                  location: "Proposal.replaceOrCreate"
                 });
-                channel.ack(msg);
-                break;
+              } else {
+                if (proposalInstance) {
+                  logger.logInfo("Proposal was created/updated", {
+                    proposalId: proposalData.proposalId
+                  });
+                }
               }
-              default: {
-                channel.ack(msg);
-                break;
-              }
-              }
-            } catch (error) {
-              logger.logError(error.message, {
-                location: "channel.consume"
-              });
-            }
-          },
-          {
-            noAck: false
+            });
+            channel.ack(msg);
+            break;
           }
-        );
-      }
-    });
+          default: {
+            channel.ack(msg);
+            break;
+          }
+          }
+        } catch (error) {
+          logger.logError(error.message, {
+            location: "channel.consume"
+          });
+        }
+      },
+      {
+        noAck: false
+      });
+    } catch (error) {
+      logger.logError(error.message, {
+        location: "startConsumer",
+        connection
+      });
+    }
   };
+
   const sendNotificationEmail = () => {
     if ("smtpMessage" in config && "to" in config.smtpMessage && config.smtpMessage.to) {
       const subjectText = "Failed to connect to RabbitMQ";
@@ -128,16 +124,15 @@ module.exports = function (app) {
       mailText += JSON.stringify(connectionDetails, null, 3);
       utils.sendMail(config.smtpMessage.to, "", subjectText, mailText, null, null);
     } else {
-      logger.logWarn("smtpMessage is not configured properly no email was sent",{
+      logger.logWarn("smtpMessage is not configured properly no email was sent", {
         location: "sendNotificationEmail"
       });
     }
   };
 
   let connectionAttempts = 0;
-  const connect = () => {
-        
-    amqp.connect(connectionDetails, function (error, connection) {
+  const connect = async () => {
+    await amqp.connect(connectionDetails, async function (error, connection) {
       if (error) {
         logger.logError(error.message, {
           location: "amqp.connect",
@@ -174,9 +169,10 @@ module.exports = function (app) {
       });
       console.log("RABBITMQ - Connected");
       connectionAttempts = 0;
-      startConsumer(connection);
+      await startConsumer(connection);
     });
   };
+
   const rabbitMqEnabled = config.rabbitmq ? config.rabbitmq.enabled : false;
   if (rabbitMqEnabled) {
     if (config.rabbitmq.host) {
@@ -192,7 +188,7 @@ module.exports = function (app) {
         connectionDetails = { ...connectionDetails, port: config.rabbitmq.port };
       }
       logger.logInfo("Connecting to RabbitMq", connectionDetails);
-      connect();
+      await connect();
     }
   }
 };


### PR DESCRIPTION
## Description

Update RabbitMq consumer to use fanout instead of direct.

## Motivation

The user office message broker has changed from direct to fanout.

## Changes:

* Change from amqplib callbacks to promises
* Add code to assert fanout exchange

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
