### PR TITLE
Fix for retrieve job flag handling

### DIFF
--- a/common/models/attachment.json
+++ b/common/models/attachment.json
@@ -20,7 +20,7 @@
     },
     "caption": {
       "type": "string",
-      "description": "Attachment caption to show in catanie",
+      "description": "Attachment caption to show in frontend",
       "default": ""
     }
   },

--- a/server/boot/handleJobSideEffects.js
+++ b/server/boot/handleJobSideEffects.js
@@ -18,12 +18,20 @@ module.exports = (app) => {
       }
     };
     switch (jobType) {
-    case jobTypes.ARCHIVE: //Intentional fall through
-    case jobTypes.RETRIEVE: {
+    case jobTypes.ARCHIVE: {
       const values = {
         "$set": {
           "datasetlifecycle.archivable": false,
           "datasetlifecycle.retrievable": false,
+          [`datasetlifecycle.${jobType}StatusMessage`]: statusMessage[jobType]
+        }
+      };
+      await Dataset.updateAll(filter, values);
+    }
+      break;
+    case jobTypes.RETRIEVE: {
+      const values = {
+        "$set": {
           [`datasetlifecycle.${jobType}StatusMessage`]: statusMessage[jobType]
         }
       };

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -127,8 +127,11 @@ var testRetrieveJob = {
   }
 };
 var app;
-before(function () {
+
+before(function(done) {
   app = require("../server/server");
+  console.log("Waiting for 5 seconds for boot tasks to finish: ",new Date());
+  setTimeout(done,5000);
 });
 
 describe("Test New Job Model", () => {
@@ -397,9 +400,6 @@ describe("Test New Job Model", () => {
       });
   });
 
-
-
-
   it("Adds a new retrieve job request on same dataset, which should  succeed now", function (done) {
     request(app)
       .post("/api/v3/Jobs?access_token=" + accessTokenIngestor)
@@ -417,14 +417,25 @@ describe("Test New Job Model", () => {
       });
   });
 
+  it("Read contents of dataset 1 after retrieve job and make sure that still retrievable", function (done) {
+    request(app)
+      .get("/api/v3/Datasets/" + pid1 + "?access_token=" + accessTokenIngestor)
+      .set("Accept", "application/json")
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .end((err, res) => {
+        if (err)
+          return done(err);
+        res.body.should.have.nested.property("datasetlifecycle.retrievable").and.equal(true);
+        done();
+      });
+  });
+
   it("Send an update status to the dataset", function (done) {
     request(app)
       .put("/api/v3/Datasets/" + pid1 + "?access_token=" + accessTokenArchiveManager)
       .send({
         "datasetlifecycle": {
-          "archiveReturnMessage": {
-            "text": "This is the result of the archiving process test message"
-          },
           "retrieveReturnMessage": {
             "text": "Some dummy retrieve message"
           },
@@ -436,7 +447,7 @@ describe("Test New Job Model", () => {
       .end(function (err, res) {
         if (err)
           return done(err);
-        res.body.should.have.nested.property("datasetlifecycle.archiveReturnMessage");
+        res.body.should.have.nested.property("datasetlifecycle.retrieveReturnMessage");
         done();
       });
   });


### PR DESCRIPTION
## Description

Fixes handling of retrieve flags

## Motivation

The retrievable flag should stay true when submitting a retrieve jobs

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [*] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
