### PR TITLE
Change ACL for some endpoints to relation models (Related to changes in the frontend)

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -107,7 +107,7 @@ module.exports = function(Dataset) {
   });
   Dataset.beforeRemote("prototype.__get__attachments", function(ctx, unused, next){
     checkACLtoRelatedModel(ctx, next);
-  })
+  });
 
   Dataset.beforeRemote("prototype.__get__origdatablocks", function(ctx, unused, next){
     checkACLtoRelatedModel(ctx, next);
@@ -132,7 +132,7 @@ module.exports = function(Dataset) {
             || ctx.instance.accessGroups && groups.some(g => ctx.instance.accessGroups.indexOf(g) !== -1)
             || ctx.instance.sharedWith && groups.some(g =>  ctx.instance.sharedWith.indexOf(g) !== -1)
             || groups.indexOf(ctx.instance.instrumentGroup) !== -1))) {
-        return next();
+      return next();
     }
     return next(error);
   };

--- a/common/models/dataset.json
+++ b/common/models/dataset.json
@@ -180,7 +180,10 @@
                 "fullfacet",
                 "fullquery",
                 "metadataKeys",
-                "thumbnail"
+                "thumbnail",
+                "__get__origdatablocks",
+                "__get__datablocks",
+                "__get__attachments"
             ]
         },
         {


### PR DESCRIPTION
## Description
To fetch dataset details for each tab on demand the ACLs for some endpoints must be changed.
## Changes:
- Enable access to these endpoints when the dataset has been published or user is owner. Not sure if this endpoints should still be closed even for public dataset `"__get__datablocks"`  @stephan271 could you verify?
```
  "__get__origdatablocks",
  "__get__datablocks",
  "__get__attachments"
```
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
