### PR TITLE
Avoid gitlab workflows when not in SciCatProject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   gitlab:
     name: Build and deploy
     needs: [test]
-    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push' && github.repository_owner == 'SciCatProject'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger ESS pipeline


### PR DESCRIPTION
## Description
The github actions launch gitlab CI for ESS and PSI.

At ALS, we are building CI based more entirely on GitHub Actions, through forks in our own organization. 

This fails for us in the backend repository because we don't have keys for the gitlab CI.

This PR adds a condition that the builds only get run if the github organization is SciCatProject. This should preserve the current behavior for PSI and ESS, while allowing GitHub actions to complete in forks of the projects. 