### PR TITLE
Define new auth Strategy to comply with oidc 0.1.1

### DIFF
--- a/server/boot/oidcCompatibleStrategy.js
+++ b/server/boot/oidcCompatibleStrategy.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var OIDCStrategy = require("passport-openidconnect");
+
+function _changeVerifyInputOrder(_verify) {
+  return function(req, iss, uiProfile, idProfile, context, idToken, 
+    accessToken, refreshToken, params, verified) {
+    return _verify(req, iss, idProfile, uiProfile, idToken, 
+      accessToken, refreshToken, params, verified, context);
+  };
+}
+
+class Strategy extends OIDCStrategy {
+
+  constructor(options, verify) {
+    options.skipUserProfile = false;
+    super(options, _changeVerifyInputOrder(verify));
+  }
+}
+
+exports._changeVerifyInputOrder = _changeVerifyInputOrder;
+exports.Strategy = Strategy;

--- a/test/oidcCompatibleStrategy.js
+++ b/test/oidcCompatibleStrategy.js
@@ -1,0 +1,17 @@
+"use strict";
+
+// process.env.NODE_ENV = 'test';
+
+var chai = require("chai");
+var inputOrderChanger = require("../server/boot/oidcCompatibleStrategy")._changeVerifyInputOrder;
+
+
+describe("Check that the verify decorator changes the input order in the function signature", () => {
+  
+  it("should change the input order", function() {
+    const dummyFunction = function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) {
+      return [a0,a1,a2,a3,a4,a5,a6,a7,a8,a9];
+    };
+    chai.expect(inputOrderChanger(dummyFunction)(0,1,2,3,4,5,6,7,8,9)).to.be.eql([0,1,3,2,5,6,7,8,9,4]);
+  });
+});


### PR DESCRIPTION
## Description

Should close #613.

### How to use the new class:

The passportConfigurator class allows specifying a module which to pull the AuthStrategy from. This newly defined class can be set in the providers.json file, in the field `module`. This also enables every RI to decide if to use the fix or not.
Please note: the path to module in the providers.json file must be absolute, as it is later loaded from a node_module.
See here an example of providers.json file, using this class:
![image](https://user-images.githubusercontent.com/50220438/159944341-88b1207c-2dd5-4183-897a-340320408088.png)

## Motivation

It implements solution 3 of #613 
## Fixes:

* Items added

## Changes:

* server/boot/oidcCompatibleStrategy.js --> defines a new strategy subclassing the existing OIDC strategy and fixing the order of the input params. 

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [x] Toggle added for new features?
