### PR TITLE
Call to JSON on publication to fix post to oaipmh

### DIFF
--- a/common/models/published-data.js
+++ b/common/models/published-data.js
@@ -234,7 +234,7 @@ module.exports = function (PublishedData) {
 
       const syncOAIPublication = {
         method: "POST",
-        body: pub,
+        body: pub.toJSON(),
         json: true,
         uri: OAIServerUri,
         headers: {


### PR DESCRIPTION
## Description

Data being sent to oai/Publication is in the wrong format because the whole PublishedData object is sent, and not only its JSON form
## Motivation

Select the right field
## Fixes:

* common/models/published-data.js -> add to JSON to select correct fields of the pub Model

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
