### PR TITLE
Fix condition of email policy concat on retrieve

### DIFF
--- a/server/boot/handleJobSideEffects.js
+++ b/server/boot/handleJobSideEffects.js
@@ -93,7 +93,7 @@ module.exports = (app) => {
       break;
     case jobTypes.RETRIEVE: {
       const { retrieveEmailNotification, retrieveEmailsToBeNotified } = policy;
-      if (retrieveEmailNotification) {
+      if (retrieveEmailsToBeNotified) {
         to += "," + retrieveEmailsToBeNotified.join();
       }
       // Always notify at failure


### PR DESCRIPTION
## Description

Check if to append email receivers based on the policy should check the correct field

## Motivation

Fix field check, inspecting if `retrieveEmailsToBeNotified` is not empty 
## Fixes:

* Fix field check, inspecting if `retrieveEmailsToBeNotified` is not empty 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
