### PR TITLE
change license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "type": "",
     "url": ""
   },
-  "license": "GPL-3.0",
+  "license": "BSD-3-Clause",
   "description": "dacat-api",
   "snyk": true
 }


### PR DESCRIPTION
The license file was recently changed to switch to BSD-3 clause. This PR updates package.json similarly.
