### PR TITLE
Partial matching of strings in generateScientificExpression

### DIFF
--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -1,6 +1,7 @@
 "use strict";
 const utils = require("./utils");
 const lodash = require("lodash");
+const escapeStringRegexp = require('escape-string-regexp')
 module.exports = function (MongoQueryableModel) {
 
   // to get access to other models
@@ -743,6 +744,23 @@ module.exports = function (MongoQueryableModel) {
         {
           [`${matchKeyGeneric}.value`]: {
             $eq: rhs,
+          }
+        }
+        ]
+      });
+      break;
+    }
+    case "CONTAINS_STRING": {
+      const escapedRhs = escapeStringRegexp(rhs);
+      match.$and.push({
+        $or: [{
+          [matchKeyGeneric]: {
+            $regex: escapedRhs,
+          }
+        },
+        {
+          [`${matchKeyGeneric}.value`]: {
+            $regex: escapedRhs,
           }
         }
         ]


### PR DESCRIPTION
## Description
This PR adds an additional `CONTAINS_STRING` condition to the `generateScientificExpression` function to filter within strings in scientific metadata.

## Motivation

When defining our meta data schemas we realized that it would be very helpful for us to also filter on partially matching strings in the scientific metadata. However, so far there is only `EQUAL_TO_STRING` for text based entries in scientific metadata so we propose an additional `CONTAINS_STRING` which should work on simple strings as well as on lists. Here is an example:

```json
"scientificMetadata": {
        "localContact": "John Doe",
        "experimentalists": [
                "John Doe",
                "Max Mustermann"
         ]
```
The idea of the proposed `CONTAINS_STRING` is that it would match e.g. `John` in both cases (as `localContact` as well as in  `experimentalists`)

## Changes:

* additinal condition for `generateScientificExpression` in `mongo-queryable.js`
* the related frontend changes can be found in https://github.com/SciCatProject/frontend/pull/974

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
