### PR TITLE
Fix GET dataset by ID authorisation check

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -90,20 +90,16 @@ module.exports = function(Dataset) {
     next();
   });
 
-  Dataset.beforeRemote("findById", function(ctx, unused, next) {
+  Dataset.afterRemote("findById", function(ctx, unused, next) {
     const accessToken = ctx.args.options.accessToken;
+    let error;
     if (!accessToken) {
-      if (!ctx.args.filter) {
-        ctx.args.filter = { where: { isPublished: true } };
-      } else {
-        if (!ctx.args.filter.where) {
-          ctx.args.filter.where = { isPublished: true };
-        } else {
-          ctx.args.filter.where["isPublished"] = true;
-        }
+      if (ctx.result && !ctx.result.isPublished) {
+        error = new Error("Dataset is not public");
+        error.status = 403;
       }
     }
-    next();
+    next(error);
   });
   Dataset.beforeRemote("prototype.__get__attachments", function(ctx, unused, next){
     checkACLtoRelatedModel(ctx, next);

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -91,6 +91,22 @@ describe("Simple Dataset tests", () => {
         done();
       });
   });
+  
+  it("should fail fetching this new dataset", function(done) {
+    request(app)
+      .get("/api/v3/Datasets/" + pid)
+      .set("Accept", "application/json")
+      .expect(403)
+      .expect("Content-Type", /json/)
+      .end((err, res) => {
+        if (err) return done(err);
+        res.body.should.have.property("error");
+        res.body.error.should.have.property("statusCode").and.equal(403);
+        res.body.error.should.have.property("name").and.equal("Error");
+        res.body.error.should.have.property("message").and.equal("Dataset is not public");
+        done();
+      });
+  });
 
   it("should add a new attachment to this dataset", function(done) {
     const testAttachment = {


### PR DESCRIPTION
## Description

Should fix #682 
## Motivation
Loopback filter seems to be ignored when using the dataset/id endpoint. The check now takes place in the afterMethod

## Fixes:

* common/models/dataset.js change beforeMethod with afterMethod to check if request is authorised

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
