### PR TITLE
Protect case sourcefolder=slash

### DIFF
--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -352,10 +352,9 @@ module.exports = function(Dataset) {
       // sourceFolder handling
       if (ctx.instance.sourceFolder) {
         // remove trailing slashes
-        ctx.instance.sourceFolder = ctx.instance.sourceFolder.replace(
-          /\/$/,
-          ""
-        );
+        if (ctx.instance.sourceFolder !== "/") {
+          ctx.instance.sourceFolder = ctx.instance.sourceFolder.replace(/\/$/,"");
+        }
         // autofill datasetName
         if (!ctx.instance.datasetName) {
           var arr = ctx.instance.sourceFolder.split("/");


### PR DESCRIPTION
## Description

This PR prevents the removal of the trailing slash when the dataset `sourceFolder` is equal to `/`

## Motivation

The trailing slash is removed from `sourceFolder`, which is fine for normal `sourceFolder`, but not when it is equal to `/` because nothing is left over and then it looks like an undefined `sourceFolder`.

## Fixes:

* Check if `sourceFolder` is not equal to `/` before removing the trailing slash

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
