### PR TITLE
Fix access groups

### DIFF
--- a/server/boot/0-script.js
+++ b/server/boot/0-script.js
@@ -162,7 +162,13 @@ module.exports = function (app) {
                                     u.profile.username;
               ctx.args.options.currentUserEmail =
                                     u.profile.email;
-              groups = u.profile.accessGroups.concat(u.profile.email);
+              if (!u.profile.accessGroups) {
+                groups = [];
+              } else if (u.profile.accessGroups instanceof Array) {
+                groups = u.profile.accessGroups.concat(u.profile.email);
+              } else {
+                return next(new Error("accessGroups type mismatch"));
+              }
               // check if a normal user or an internal ROLE
               if (typeof groups === "undefined") {
                 groups = [];

--- a/test/accessGroups.js
+++ b/test/accessGroups.js
@@ -1,0 +1,104 @@
+"use strict";
+
+var chai = require("chai");
+var chaiHttp = require("chai-http");
+var request = require("supertest");
+var should = chai.should();
+
+chai.use(chaiHttp);
+
+var app;
+var u;
+var userIdentity;
+
+before(function() {
+  app = require("../server/server");
+
+  app.models.User.findOrCreate({
+    where: { username: "noGroup" }
+  }, {
+    username: "noGroup",
+    password: "aman",
+    email: "no.group@your-site.com",
+    global: "false",
+  }, function(err, instance, _created) {
+    if (err)
+      return(err);
+    else
+      u = instance;
+
+    app.models.UserIdentity.findOrCreate({
+      where: { userId: u.id }
+    }, {
+      userId: u.id,
+      profile: {
+        username: u.username,
+        email: u.email,
+      }
+    }, function(err, instance, _created) {
+      if (err)
+        return(err);
+      else
+        userIdentity = instance;
+    });
+  });
+});
+
+describe("Access groups test", function() {
+  it("Make a request with user that has no accessGroups in his profile should succeed", async function() {
+    const loginResponse = await request(app)
+      .post("/api/v3/Users/Login?include=user")
+      .send({
+        username: "noGroup",
+        password: "aman"
+      })
+      .set("Accept", "application/json");
+
+    const datasetResponse = await request(app)
+      .get(`/api/v3/Datasets?access_token=${loginResponse.body.id}`)
+      .set("Accept", "application/json");
+    datasetResponse.statusCode.should.equal(200);
+  });
+
+  it("Make a request with user that has not an Array as accessGroups in his profile should fail", async function() {
+    userIdentity.profile.accessGroups = 1;
+    userIdentity.save();
+    const loginResponse = await request(app)
+      .post("/api/v3/Users/Login?include=user")
+      .send({
+        username: "noGroup",
+        password: "aman"
+      })
+      .set("Accept", "application/json");
+
+    const datasetResponse = await request(app)
+      .get(`/api/v3/Datasets?access_token=${loginResponse.body.id}`)
+      .set("Accept", "application/json");
+    datasetResponse.statusCode.should.equal(500);
+  });
+
+  it("Make a request with user that has an Array as accessGroups in his profile should succeed", async function() {
+    userIdentity.profile.accessGroups = ["group1", "goup2"];
+    userIdentity.save();
+    const loginResponse = await request(app)
+      .post("/api/v3/Users/Login?include=user")
+      .send({
+        username: "noGroup",
+        password: "aman"
+      })
+      .set("Accept", "application/json");
+
+    const datasetResponse = await request(app)
+      .get(`/api/v3/Datasets?access_token=${loginResponse.body.id}`)
+      .set("Accept", "application/json");
+    datasetResponse.statusCode.should.equal(200);
+  });
+});
+
+after(function() {
+  userIdentity.profile = {
+    username: u.username,
+    email: u.email,
+  };
+  userIdentity.save();
+});

--- a/test/accessGroups.js
+++ b/test/accessGroups.js
@@ -27,8 +27,7 @@ before(function() {
     else
       u = instance;
 
-    app.models.UserIdentity.findOrCreate({
-      where: { userId: u.id }
+    app.models.UserIdentity.findOrCreate({ where: { userId: u.id }
     }, {
       userId: u.id,
       profile: {
@@ -95,10 +94,15 @@ describe("Access groups test", function() {
   });
 });
 
-after(function() {
+afterEach(function() {
   userIdentity.profile = {
     username: u.username,
     email: u.email,
   };
   userIdentity.save();
+});
+
+after(function() {
+  u.destroy();
+  userIdentity.destroy();
 });


### PR DESCRIPTION
## Description

Fixes [#685](https://github.com/SciCatProject/backend/issues/685)

## Fixes:

* Check if `accessGroups` is an array before trying to use `concat()`. Falls back to empty array if `null` and throws an error if type is incorrect.

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
