### PR TITLE
fixed undefined email in access groups bug

### DIFF
--- a/server/boot/0-script.js
+++ b/server/boot/0-script.js
@@ -165,7 +165,10 @@ module.exports = function (app) {
               if (!u.profile.accessGroups) {
                 groups = [];
               } else if (u.profile.accessGroups instanceof Array) {
-                groups = u.profile.accessGroups.concat(u.profile.email);
+                groups = u.profile.accessGroups;
+                if (u.profile.email !== undefined){
+                  groups = u.profile.accessGroups.concat(u.profile.email);
+                }
               } else {
                 return next(new Error("accessGroups type mismatch"));
               }

--- a/test/accessGroups.js
+++ b/test/accessGroups.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { expect } = require("chai");
 var chai = require("chai");
 var chaiHttp = require("chai-http");
 var request = require("supertest");
@@ -9,9 +10,43 @@ chai.use(chaiHttp);
 
 var app;
 var u;
+var u2;
 var userIdentity;
+var userIdentity2;
 
-before(function() {
+var testUndefinedInstrumentGroup = {
+  "principalInvestigator": "bertram.astor@grumble.com",
+  "endTime": "2011-09-14T06:31:25.000Z",
+  "creationLocation": "/PSI/SLS/MX",
+  "dataFormat": "Upchuck pre 2017",
+  "scientificMetadata": {
+    "beamlineParameters": {
+      "Monostripe": "Ru/C",
+      "Ring current": {
+        "v": 0.402246,
+        "u": "A"
+      },
+      "Beam energy": {
+        "v": 22595,
+        "u": "eV"
+      }
+    },
+  },
+  "owner": "Bertram Astor",
+  "ownerEmail": "bertram.astor@grumble.com",
+  "orcidOfOwner": "unknown",
+  "contactEmail": "bertram.astor@grumble.com",
+  "sourceFolder": "/iramjet/tif/",
+  "size": 0,
+  "creationTime": "2011-09-14T06:08:25.000Z",
+  "description": "None",
+  "isPublished": false,
+  "ownerGroup": "p10029",
+  "accessGroups": ["excludeNoGroup"],
+  "proposalId": "10.540.16635/20110123"
+};
+
+before(function () {
   app = require("../server/server");
 
   app.models.User.findOrCreate({
@@ -21,30 +56,62 @@ before(function() {
     password: "aman",
     email: "no.group@your-site.com",
     global: "false",
-  }, function(err, instance, _created) {
+  }, function (err, instance, _created) {
     if (err)
-      return(err);
+      return (err);
     else
       u = instance;
 
-    app.models.UserIdentity.findOrCreate({ where: { userId: u.id }
+    app.models.UserIdentity.findOrCreate({
+      where: { userId: u.id }
     }, {
       userId: u.id,
       profile: {
         username: u.username,
         email: u.email,
       }
-    }, function(err, instance, _created) {
+    }, function (err, instance, _created) {
       if (err)
-        return(err);
+        return (err);
       else
         userIdentity = instance;
     });
   });
+
+  app.models.User.findOrCreate({
+    where: { username: "hasGroup" }
+  }, {
+    username: "hasGroup",
+    password: "aman",
+    email: "has.group@your-site.com",
+    global: "false",
+  }, function (err, instance, _created) {
+    if (err){
+
+      return (err);
+    }
+    else
+      u2 = instance;
+
+    app.models.UserIdentity.findOrCreate({
+      where: { userId: u2.id }
+    }, {
+      userId: u2.id,
+      profile: {
+        username: u2.username,
+        email: u2.email,
+      }
+    }, function (err, instance, _created) {
+      if (err)
+        return (err);
+      else
+        userIdentity2 = instance;
+    });
+  });
 });
 
-describe("Access groups test", function() {
-  it("Make a request with user that has no accessGroups in his profile should succeed", async function() {
+describe("Access groups test", function () {
+  it("Make a request with user that has no accessGroups in his profile should succeed", async function () {
     const loginResponse = await request(app)
       .post("/api/v3/Users/Login?include=user")
       .send({
@@ -59,7 +126,7 @@ describe("Access groups test", function() {
     datasetResponse.statusCode.should.equal(200);
   });
 
-  it("Make a request with user that has not an Array as accessGroups in his profile should fail", async function() {
+  it("Make a request with user that has not an Array as accessGroups in his profile should fail", async function () {
     userIdentity.profile.accessGroups = 1;
     userIdentity.save();
     const loginResponse = await request(app)
@@ -76,7 +143,7 @@ describe("Access groups test", function() {
     datasetResponse.statusCode.should.equal(500);
   });
 
-  it("Make a request with user that has an Array as accessGroups in his profile should succeed", async function() {
+  it("Make a request with user that has an Array as accessGroups in his profile should succeed", async function () {
     userIdentity.profile.accessGroups = ["group1", "goup2"];
     userIdentity.save();
     const loginResponse = await request(app)
@@ -92,17 +159,68 @@ describe("Access groups test", function() {
       .set("Accept", "application/json");
     datasetResponse.statusCode.should.equal(200);
   });
+
+  it("Makes a request with an undefined profile email and does not get a dataset with an undefined intrumentGroup but with different accessGroups", async function () {
+    userIdentity.profile.email = [];
+    userIdentity.save();
+
+    userIdentity2.profile.accessGroups = ["excludeNoGroup"];
+    userIdentity2.save();
+
+    const hasGroupLoginResponse = await request(app)
+      .post("/api/v3/Users/Login?include=user")
+      .send({
+        username: "hasGroup",
+        password: "aman"
+      })
+      .set("Accept", "application/json").expect(200);
+
+
+    await request(app)
+      .post("/api/v3/RawDatasets?access_token=" + hasGroupLoginResponse.body.id)
+      .send(testUndefinedInstrumentGroup)
+      .set("Accept", "application/json")
+      .expect(200)
+      .expect("Content-Type", /json/);
+
+    const noGroupLoginResponse = await request(app)
+      .post("/api/v3/Users/Login?include=user")
+      .send({
+        username: "noGroup",
+        password: "aman"
+      })
+      .set("Accept", "application/json");
+
+    const datasetResponse = await request(app)
+      .get(`/api/v3/Datasets?access_token=${noGroupLoginResponse.body.id}`)
+      .set("Accept", "application/json");
+    datasetResponse.statusCode.should.equal(200);
+
+    datasetResponse.body.forEach(element => {
+      expect(element.isPublished).to.be.true;
+
+    });
+  });
+
 });
 
-afterEach(function() {
+afterEach(function () {
   userIdentity.profile = {
     username: u.username,
     email: u.email,
   };
   userIdentity.save();
+
+  userIdentity2.profile = {
+    username: u2.username,
+    email: u2.email,
+  };
+  userIdentity2.save();
 });
 
-after(function() {
+after(function () {
   u.destroy();
   userIdentity.destroy();
+  u2.destroy();
+  userIdentity2.destroy();
 });

--- a/test/accessGroups.js
+++ b/test/accessGroups.js
@@ -160,8 +160,9 @@ describe("Access groups test", function () {
     datasetResponse.statusCode.should.equal(200);
   });
 
-  it("Makes a request with an undefined profile email and does not get a dataset with an undefined intrumentGroup but with different accessGroups", async function () {
-    userIdentity.profile.email = [];
+  it("Makes a request with an undefined profile email and does not get a dataset with an undefined sharedWith but with different accessGroups", async function () {
+    userIdentity.profile.email = undefined;
+    userIdentity.profile.accessGroups = [];
     userIdentity.save();
 
     userIdentity2.profile.accessGroups = ["excludeNoGroup"];


### PR DESCRIPTION
## Description

PR fixes security issue where when a user's profile email is undefined it will be concatenated to the groups array. This prevents an undefined value from being put in the array of groups.

## Motivation
When an instrumentGroup is undefined on any dataset this will give that user access to that dataset, regardless of whether that user and dataset have matching groups.



## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
