### PR TITLE
Simplify workflows and use ghcr on release too

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,34 +5,13 @@ on:
     branches: [master]
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: test
-        run: |
-          cp CI/ESS/docker-compose.gitlab.yaml docker-compose.yaml
-          docker-compose down --remove-orphans
-          docker-compose pull
-          docker-compose up --build --exit-code-from scicat-backend
-          docker-compose down
           
   build:
     name: Build and push Docker image with latest tag
     runs-on: ubuntu-latest
-    needs: [test]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
 
       - name: Login to GHCR
         uses: docker/login-action@v2
@@ -46,7 +25,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/scicatproject/backend:latest
+          tags: ghcr.io/scicatproject/backend:latest,ghcr.io/scicatproject/backend:${{ github.sha }}
 
   gitlab:
     name: Deploy

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -1,13 +1,12 @@
 name: Main Release
 
 on:
-  create:
-    tags:
-      - v[0-9]**
+  release:
+    types: [published]
 
 jobs:
   test:
-    name: Test
+    name: Test and publish image to ghcr on release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,36 +20,16 @@ jobs:
           docker-compose up --build --exit-code-from scicat-backend
           docker-compose down
 
-  new-main-release:
-    name: New main release on the main branch and docker image
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Checking release
-        run: echo "Releasing version ${{ github.ref_name }}"
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: scicatproject/backend:${{ github.ref_name }},scicatproject/backend:stable
+          tags: ghcr.io/scicatproject/backend:${{ github.event.release.tag_name }},ghcr.io/scicatproject/backend:stable,ghcr.io/scicatproject/backend:latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Test and build image on PR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -20,45 +20,9 @@ jobs:
           docker-compose up --build --exit-code-from scicat-backend
           docker-compose down
 
-  build:
-    name: Build and push Docker image with branch tag
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      # For debugging capture the selected branch
-      - name: Branch
-        run: echo "Branch ${{ github.head_ref }}"
-
-      # Replace all slashes with underscore because github container registry does't accept slashes as valid tag names
-      - name: Extract branch name without slashes
-        id: extract_branch
-        shell: bash
-        run: |
-          # Extract branch name
-          BRANCH_NAME=${{ github.head_ref }}
-
-          # set output variable accessible in the action
-          echo ::set-output name=branch::${BRANCH_NAME} | sed 's/\//\_/g'
-
-      - name: Login to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
+      - name: Build
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: true
-          tags: ghcr.io/scicatproject/backend:${{ steps.extract_branch.outputs.branch }}
+          push: false
+          tags: test_build


### PR DESCRIPTION
## Description

Review and simplification of existing workflows, triggered by failing steps when a PR was opened from a fork

## Motivation

- Avoid pushing on PR, given the possible permission problems on PRs from forks. 
- Use GHCR as container registry for releases too
- Simplify workflows by removing non-needed steps
- Add commit sha tag on push to ghcr after merge
- remove test jobs from push to master, as changes on master require having gone through a successful and approved PR