### PR TITLE
Add datasetName and isPublished to index for speed

### DIFF
--- a/common/models/dataset.json
+++ b/common/models/dataset.json
@@ -95,6 +95,7 @@
         },
         "datasetName": {
             "type": "string",
+            "index": true,
             "description": "A name for the dataset, given by the creator to carry some semantic meaning. Useful for display purposes e.g. instead of displaying the pid. Will be autofilled if missing using info from sourceFolder"
         },
         "classification": {
@@ -111,6 +112,7 @@
         },
         "isPublished": {
             "type": "boolean",
+            "index": true,
             "description": "Flag is true when data are made publically available"
         },
         "sharedWith": {


### PR DESCRIPTION
## Description

Add datasetName and isPublished to index to increase query speed

## Motivation

Increase query speed, as isPublished and datasetName are fields usually used to query

## Changes:

* common/models/dataset.json has more indexes

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
