### PR TITLE
Email 365

### DIFF
--- a/server/boot/graph-mail.js
+++ b/server/boot/graph-mail.js
@@ -95,15 +95,21 @@ class M365Email {
 
 }
 
+exports.M365Email = M365Email;
 
 exports.sendEmailM365 = async(to, cc, subjectText, mailText, e, next, html = null) => {
   try {
     const client = new M365Authenticate(config.smtpSettings);
     const emailSender = new M365Email(client);
     const messageCofig = config.smtpMessage;
-    const message = emailSender.createEmailAsJson({ to: to.split(","), cc: cc ?cc.split(","): [] }, html, messageCofig.from, messageCofig.replyTo, messageCofig.subject);
+    const message = emailSender.createEmailAsJson(
+      { to: to.split(","), cc: cc ?cc.split(","): [] }, 
+      html, 
+      messageCofig.from, 
+      messageCofig.replyTo, 
+      messageCofig.subject
+    );
     emailSender.sendNotification(messageCofig.from, message);
-
   } catch (err) {
     console.log(err);
   }

--- a/server/boot/graph-mail.js
+++ b/server/boot/graph-mail.js
@@ -1,0 +1,111 @@
+"use strict";
+const config = require("../../server/config.local");
+const superagent = require("superagent");
+  
+class M365Authenticate {
+  constructor(config){
+    this.tenantId = config.auth.tenantId || "";
+    this.clientId = config.auth.clientId || "";
+    this.clientSecret = config.auth.clientSecret || "";
+    this.aadEndpoint = config.aadEndpoint || "";
+    this.graphEndpoint = config.graphEndpoint || "";
+  }
+
+  async getAuthToken() {
+    const formData = {
+      "grant_type": "client_credentials",
+      scope: `${this.graphEndpoint}/.default`,
+      "client_id": this.clientId,
+      "client_secret": this.clientSecret,
+    };
+ 
+    const tokenObject = await superagent.post(
+      `${this.aadEndpoint}/${this.tenantId}/oauth2/v2.0/token`)
+      .set({ "Content-Type": "application/x-www-form-urlencoded" })
+      .send(formData);
+    return tokenObject.body.access_token;
+  }
+
+}
+
+class M365Email {
+  constructor(authClass) {
+    this.authClass = authClass;
+    this.graphEndpoint = authClass.graphEndpoint;
+  }
+
+  createRecipients(rcpts) {
+    return rcpts.filter(r => r).map((rcpt) => {
+      return {
+        emailAddress: {
+          address: rcpt,
+        },
+      };
+    });
+  }
+   
+  createEmailAsJson(rcpts, body, from, replyTo, subject) {
+    let messageAsJson = {
+      message: {
+        subject: subject,
+        from: {
+          emailAddress: { address: from }
+        },
+        replyTo: [{
+          emailAddress: { address: replyTo }
+        }],
+        body: {
+          contentType: "HTML",
+          content: body,
+        },
+      },
+    };
+   
+    messageAsJson = this.addRecipients(messageAsJson, rcpts);
+    return messageAsJson;
+  }
+  
+  async sendNotification(from, message){
+    const accessToken = await this.authClass.getAuthToken();
+    try {
+      const response = await superagent.post(
+        `${this.graphEndpoint}/v1.0/users/${from}/sendMail`)
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .set({ "Content-Type": "application/json" })
+        .send(message);
+   
+      console.log("sendNotification status", response.statusText);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  addRecipients(messageBody, rcpts = {}) {
+    const cloned = Object.assign({}, messageBody);
+   
+    Object.keys(rcpts).forEach((element) => {
+      const recipients = this.createRecipients(rcpts[element]);
+      if (recipients.length > 0) {
+        cloned.message[element + "Recipients"] = recipients;
+      }
+    });
+   
+    return cloned;
+  }
+
+}
+
+
+exports.sendEmailM365 = async(to, cc, subjectText, mailText, e, next, html = null) => {
+  try {
+    const client = new M365Authenticate(config.smtpSettings);
+    const emailSender = new M365Email(client);
+    const messageCofig = config.smtpMessage;
+    const message = emailSender.createEmailAsJson({ to: to.split(","), cc: cc ?cc.split(","): [] }, html, messageCofig.from, messageCofig.replyTo, messageCofig.subject);
+    emailSender.sendNotification(messageCofig.from, message);
+
+  } catch (err) {
+    console.log(err);
+  }
+  return next && next(e);
+};

--- a/server/boot/handleJobSideEffects.js
+++ b/server/boot/handleJobSideEffects.js
@@ -3,8 +3,10 @@ const fs = require("fs");
 const config = require("../config.local");
 const utils = require("../../common/models/utils");
 const Handlerbars = require("handlebars");
+const graphMail = require("./graph-mail");
 module.exports = (app) => {
 
+  const sendMail = config.smtpSettings && config.smtpSettings.graphEndpoint ? graphMail.sendEmailM365: utils.sendMail;
   const Job = app.models.Job;
   const jobTypes = Job.types;
   const Dataset = app.models.Dataset;
@@ -72,7 +74,7 @@ module.exports = (app) => {
     const emailTemplate = Handlerbars.compile(htmlTemplate);
     const email = emailTemplate(emailContext);
     const subject = emailContext.subject;
-    utils.sendMail(to, cc, subject, null, null, null, email);
+    sendMail(to, cc, subject, null, null, null, email);
   };
 
   // Check policy settings if mail should be sent

--- a/test/graph-mail.js
+++ b/test/graph-mail.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const { sendEmailM365, M365Email } = require("../server/boot/graph-mail.js");
+const sandbox = require("sinon").createSandbox();
+const { expect } = require("chai");
+const config = require("../server/config.local");
+
+afterEach((done) => {
+  sandbox.restore();
+  done();
+});      
+
+describe("server.boot.graph-mail", () => {
+
+  it("should sendEmailM365", () => {
+    const sendNotificationStub = sandbox.stub(M365Email.prototype, "sendNotification");
+    if (!config.smtpSettings) config.smtpSettings = {};
+    sandbox.stub(config, "smtpSettings").value({
+      auth: {
+        tenantId: "someTenant", 
+        clientId: "someClientId", 
+        clientSecret: "someClientSecret"
+      }
+    });
+    const from = "somefrom@email.com";
+    if (!config.smtpMessage) config.smtpMessage = {};
+    sandbox.stub(config, "smtpMessage").value({
+      from: "somefrom@email.com",
+      replyTo: "someto@email.com",
+      subject: "this is a subject",
+    });
+    const body = "<h1>Test from James A</h1><p>HTML message sent via MS Graph</p>";
+    sendEmailM365("some@email.com,someother@email.com", "", null, null, null, null, body);
+    const expectedMessage = { 
+      message:{ 
+        subject:"this is a subject",
+        from:{ 
+          emailAddress:{ 
+            address:"somefrom@email.com" 
+          } 
+        },
+        replyTo:[
+          { emailAddress:{ address:"someto@email.com" } }
+        ],
+        body:{ 
+          contentType:"HTML",
+          content:"<h1>Test from James A</h1><p>HTML message sent via MS Graph</p>" },
+        toRecipients:[
+          { emailAddress:{ address:"some@email.com" } },
+          { emailAddress:{ address:"someother@email.com" } }
+        ] 
+      } 
+    };
+    expect(sendNotificationStub.calledWith(from, expectedMessage)).to.be.true;
+  });
+
+});


### PR DESCRIPTION
## Description

Add component and switch to choose between smtp server or Microsoft mail365.

## Motivation

After migration to outlook365 email sender needs to be configurable depending on config

## Changes:

* added server/boot/graph-mail.js
* added test/graph-mail.js
* modified server/boot/handleJobSideEffects.js to include switch choosing between smtp or mail365 depending on config

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
