### PR TITLE
Add check on filter if empty

### DIFF
--- a/common/models/published-data.js
+++ b/common/models/published-data.js
@@ -423,7 +423,7 @@ module.exports = function (PublishedData) {
 };
 
 function addRegisteredIfUnathenticated(ctx, filterField) {
-  const filterClone = JSON.parse(JSON.stringify(filterField));
+  const filterClone = filterField? JSON.parse(JSON.stringify(filterField)): undefined;
   const accessToken = ctx.args.options.accessToken;
   if (!accessToken) {
     let filter = {};

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -243,6 +243,20 @@ describe("Test of access to published data", () => {
       });
   });
 
+  it("should get all registered data", function (done) {
+    request(app)
+      .get("/api/v3/PublishedData")
+      .set("Accept", "application/json")
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .end((err, res) => {
+        if (err) return done(err);
+        res.body.length.should.be.equal(1);
+        res.body[0].should.have.property("status").and.equal("registered");
+        done();
+      });
+  });
+
   it("should return the registered publisheddata count", function (done) {
     request(app)
       .get("/api/v3/PublishedData/count")


### PR DESCRIPTION
## Description

Fix when filter is undefined and creating the copy fails

## Motivation

When the published data filter is empty, the JSON methods fail as  they are not applicable on undefined objects
## Fixes:

* [common/published-data.js](common/published-data.js)

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
