### PR TITLE
Make resync optional, depending on oaipmh

### DIFF
--- a/common/models/published-data.js
+++ b/common/models/published-data.js
@@ -327,9 +327,21 @@ module.exports = function (PublishedData) {
     if (!config) {
       return cb("No config.local");
     }
+    const OAIServerUri = config.oaiProviderRoute;
     delete data.doi;
     delete data._id;
-    const OAIServerUri = config.oaiProviderRoute;
+    const where = {
+      doi: doi,
+    };
+    if (!OAIServerUri) {
+      const res = PublishedData.update(where, { $set: data }, function (err) {
+        if (err) {
+          return cb(err);
+        }
+      });
+
+      return cb(null, res);
+    }
     let doiProviderCredentials = {
       username: "removed",
       password: "removed",
@@ -347,10 +359,6 @@ module.exports = function (PublishedData) {
         "content-type": "application/json;charset=UTF-8",
       },
       auth: doiProviderCredentials,
-    };
-
-    const where = {
-      doi: doi,
     };
 
     (async () => {


### PR DESCRIPTION
## Description

Resync should check if oaipmh is enabled when updating published data

## Motivation

If published data is copied to oaipmh db, then resync should update both the oaipmh db and the be one. If no oaipmh only the be one is updated

## Fixes:

* check on oaipmh from config
* 
## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
