### PR TITLE
Retrieve links

### DIFF
--- a/common/models/utils.js
+++ b/common/models/utils.js
@@ -483,3 +483,20 @@ exports.superagent = (request) => {
   }
   return sao;
 };
+
+exports.isValidHttpUrl = (stringUrl) => {
+  let url;
+  try {
+    url = new URL(stringUrl);
+  } catch (_) {
+    return false;
+  }
+  return url.protocol === "http:" || url.protocol === "https:";
+};
+
+exports.transfromObjToLinksArray = (obj) => {
+  if (obj && Object.values(obj).length > 0 && Object.values(obj).every(exports.isValidHttpUrl))
+    return Object.keys(obj).map(k => `<a href="${obj[k]}">${k}</a>`);
+  else
+    return obj;
+};

--- a/server/boot/handleJobSideEffects.js
+++ b/server/boot/handleJobSideEffects.js
@@ -240,7 +240,7 @@ module.exports = (app) => {
           // add cc message in case of failure to scicat archivemanager
           const cc = (bad.length > 0 && config.smtpMessage && config.smtpMessage.from) ? config.smtpMessage.from : "";
           const creationTime = currentJobData.creationTime.toISOString().replace(/T/, " ").replace(/\..+/, "");
-          const additionalMsg = (jobType === jobTypes.RETRIEVE && good.length > 0) ? "You can now use the command 'datasetRetriever' to move the retrieved datasets to their final destination." : "";
+          const additionalMsg = "";
           const emailContext = {
             subject: `SciCat: Your ${jobType} job from ${creationTime} is finished ${failure? "with failure": "successfully"}`,
             jobFinishedNotification: {

--- a/server/boot/handleJobSideEffects.js
+++ b/server/boot/handleJobSideEffects.js
@@ -201,6 +201,8 @@ module.exports = (app) => {
       //Check that statusMessage has changed. Only run on finished job
       if (currentJobData.jobStatusMessage != oldData.jobStatusMessage && currentJobData.jobStatusMessage.indexOf("finish") !== -1) {
         const { type: jobType, id: jobId, jobStatusMessage, jobResultObject } = currentJobData;
+        if (typeof jobResultObject === "object" && jobResultObject !== null && jobResultObject.result)
+          jobResultObject.result = utils.transfromObjToLinksArray(jobResultObject.result);
         let to = currentJobData.emailJobInitiator;
         const failure = jobStatusMessage.indexOf("finishedSuccessful") === -1;
         switch(jobType) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -70,3 +70,37 @@ describe("utils.extractMetadataKeys", () => {
     chai.expect(res).to.deep.equal(utilsTestData.extractMetadataKeysExpectedData);
   });
 });
+
+describe("utils.isValidHttpUrl", () => {
+  const tests = [
+    ["http://aUrl.com", true],
+    ["https://aUrl.com", true],
+    ["aUrl.com", false],
+    ["ws://aUrl.com", false],
+    ["aUrl", false]
+  ];
+  tests.forEach(t => {
+    it(`should return ${t[1]} from ${t[0]}`, () => {
+      const res = utils.isValidHttpUrl(t[0]);
+      chai.expect(res).to.be.eql(t[1]);
+    });
+  });
+});
+
+describe("utils.transfromObjToLinksArray", () => {
+  const tests = [
+    [{ aKey: "http://aUrl" }, ["<a href=\"http://aUrl\">aKey</a>"]],
+    [{ aKey: "http://aUrl", aKey2: "http://aUrl2" }, ["<a href=\"http://aUrl\">aKey</a>", "<a href=\"http://aUrl2\">aKey2</a>"]],
+    [{ aKey: "http://aUrl", aKey2: "aNonUrl2" }, { aKey: "http://aUrl", aKey2: "aNonUrl2" }],
+    [{ aKey: "aNonUrl", aKey2: "aNonUrl2" }, { aKey: "aNonUrl", aKey2: "aNonUrl2" }],
+    [{}, {}],
+    [undefined, undefined],
+    [null, null],
+  ];
+  tests.forEach(t => {
+    it(`should attempt transforming to a ${JSON.stringify(t[1])}`, () => {
+      const res = utils.transfromObjToLinksArray(t[0]);
+      chai.expect(res).to.deep.equal(t[1]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add to the rendered template sent via email when job successful, the links to download the data, in case the jobResults.result is an object of HTTP URLs. Also, the additional message can be as well moved to the results section, making it more customisable. 

## Changes:

* jobResults.result can be transformed to array of links
* additionalMessage is avoided and it can be part of results

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
