### PR TITLE
Refactor handlebar effects to allow public retrieve

### DIFF
--- a/server/boot/handleJobSideEffects.js
+++ b/server/boot/handleJobSideEffects.js
@@ -34,7 +34,7 @@ module.exports = (app) => {
       ownerGroup: x.ownerGroup,
       sourceFolder: x.sourceFolder,
       size: x.size,
-      ...dsExtraFieldsFunc,
+      ...dsExtraFieldsFunc(x),
     }));
     return datasets;
   };
@@ -268,9 +268,7 @@ module.exports = (app) => {
 
         }
       }
-
     });
-
   };
     // Listen to events from Job
   jobEventEmitter.addListener("jobCreated", sendStartJobEmail);


### PR DESCRIPTION
## Description

Refactor handlebar effects to allow public retrieve

## Motivation

A case where a public job is submitted but still has to apply some retrieve features was needed. One can enable it, by setting the value `config.smtpMessage.publicRetrieve` to true.

## Changes:

* server/boot/handleJobSideEffects.js refactor

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [x] Toggle added for new features?
