### PR TITLE
Run number

### DIFF
--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -514,7 +514,7 @@ module.exports = function (MongoQueryableModel) {
         // input format: "creationTime:desc,creationLocation:asc"
         const sortExpr = {};
         const sortFields = limits.order.split(",");
-        const addFields = []
+        const addFields = [];
         sortFields.map(function (sortField) {
           const parts = sortField.split(":");
           const dir = parts[1] == "desc" ? -1 : 1;
@@ -526,9 +526,12 @@ module.exports = function (MongoQueryableModel) {
             fieldName = "_id";
           }
           else if (fieldName === "runNumber") {
-            addFields.push({ 
+            addFields.push({
               "runNumber": { $sum: 
-                [ "scientificMetadata.runNumber.value", "scientificMetadata.runNumber"] 
+                [ 
+                  { $toInt: "$scientificMetadata.runNumber.value" }, 
+                  { $convert: { input: "$scientificMetadata.runNumber", to: "int", onError: 0 } }
+                ]
               }
             });
           }

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -859,7 +859,7 @@ module.exports = function (MongoQueryableModel) {
     return {
       "scientificMetadata.runNumber.value": {
         $ifNull: [
-          { $toInt: "$scientificMetadata.runNumber.value" },
+          { $convert: { input: "$scientificMetadata.runNumber.value", to: "int", onError: null } },
           { $convert: { input: "$scientificMetadata.runNumber", to: "int", onError: null } }
         ]
       }

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -326,15 +326,14 @@ module.exports = function (MongoQueryableModel) {
       }
       ];
     }
+    const addedFields = addFields();
+    pipeline.push({ $addFields: addedFields });
 
     pipeline.push({
       $facet: facetObject
     });
     // console.log("Resulting aggregate query in fullfacet method:", JSON.stringify(pipeline, null, 3));
     
-    const addedFields = addFields();
-    pipeline.push({ $addFields: addedFields });
-
     app.models[options.modelName].getDataSource().connector.connect(function (err, db) {
       let mongoModel = modelName;
       if (app.models[modelName].definition.settings.mongodb &&
@@ -510,6 +509,9 @@ module.exports = function (MongoQueryableModel) {
       }
     }
 
+    const addedFields = addFields();
+    pipeline.push({ $addFields: addedFields });
+
     // }
     // final paging section ===========================================================
     if (limits) {
@@ -546,10 +548,7 @@ module.exports = function (MongoQueryableModel) {
         });
       }
     }
-
-    const addedFields = addFields();
-    pipeline.push({ $addFields: addedFields });
-
+    
     // console.log("Resulting aggregate query in fullquery method:", JSON.stringify(pipeline, null, 3));
     app.models[options.modelName].getDataSource().connector.connect(function (err, db) {
       // fetch calling parent collection

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -861,9 +861,8 @@ module.exports = function (MongoQueryableModel) {
     return {
       "scientificMetadata.runNumber.value": {
         $ifNull: [
-          { $toInt: "scientificMetadata.runNumber.value" },
-          { $convert: { input: "scientificMetadata.runNumber", to: "int", onError: null } },
-          null
+          { $toInt: "$scientificMetadata.runNumber.value" },
+          { $convert: { input: "$scientificMetadata.runNumber", to: "int", onError: null } }
         ]
       }
     };

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -514,7 +514,7 @@ module.exports = function (MongoQueryableModel) {
         // input format: "creationTime:desc,creationLocation:asc"
         const sortExpr = {};
         const sortFields = limits.order.split(",");
-        const addFields = [];
+        const addFields = {};
         sortFields.map(function (sortField) {
           const parts = sortField.split(":");
           const dir = parts[1] == "desc" ? -1 : 1;

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -526,14 +526,12 @@ module.exports = function (MongoQueryableModel) {
             fieldName = "_id";
           }
           else if (fieldName === "runNumber") {
-            addFields.push({
-              "runNumber": { $sum: 
+            addFields["runNumber"] = { $sum: 
                 [ 
                   { $toInt: "$scientificMetadata.runNumber.value" }, 
                   { $convert: { input: "$scientificMetadata.runNumber", to: "int", onError: 0 } }
                 ]
-              }
-            });
+            };
           }
           sortExpr[fieldName] = dir;
         });

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -514,6 +514,7 @@ module.exports = function (MongoQueryableModel) {
         // input format: "creationTime:desc,creationLocation:asc"
         const sortExpr = {};
         const sortFields = limits.order.split(",");
+        const addFields = []
         sortFields.map(function (sortField) {
           const parts = sortField.split(":");
           const dir = parts[1] == "desc" ? -1 : 1;
@@ -524,8 +525,17 @@ module.exports = function (MongoQueryableModel) {
           if (fieldName == idField) {
             fieldName = "_id";
           }
+          else if (fieldName === "runNumber") {
+            addFields.push({ 
+              "runNumber": { $sum: 
+                [ "scientificMetadata.runNumber.value", "scientificMetadata.runNumber"] 
+              }
+            });
+          }
           sortExpr[fieldName] = dir;
         });
+        if (addFields.length > 0) 
+          pipeline.push({ $addFields: addFields });
         pipeline.push({
           $sort: sortExpr
           // e.g. { $sort : { creationLocation : -1, creationLoation: 1 } }

--- a/common/models/mongo-queryable.js
+++ b/common/models/mongo-queryable.js
@@ -333,7 +333,7 @@ module.exports = function (MongoQueryableModel) {
       $facet: facetObject
     });
     // console.log("Resulting aggregate query in fullfacet method:", JSON.stringify(pipeline, null, 3));
-    
+
     app.models[options.modelName].getDataSource().connector.connect(function (err, db) {
       let mongoModel = modelName;
       if (app.models[modelName].definition.settings.mongodb &&
@@ -548,7 +548,6 @@ module.exports = function (MongoQueryableModel) {
         });
       }
     }
-    
     // console.log("Resulting aggregate query in fullquery method:", JSON.stringify(pipeline, null, 3));
     app.models[options.modelName].getDataSource().connector.connect(function (err, db) {
       // fetch calling parent collection

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -251,7 +251,7 @@ describe("Simple Dataset tests", () => {
   it("should fetch a filtered array of datasets", function (done) {
     const query = JSON.stringify({ 
       isPublished: false, 
-      "scientific":[{ "lhs":"runNumber","relation":"GREATER_THAN","rhs": 3, "unit": "" }]
+      "scientific": [{ "lhs": "runNumber", "relation": "EQUAL_TO_NUMERIC", "rhs": 3, "unit": "" }]
     });
     const limits = JSON.stringify({
       skip: 0,
@@ -273,7 +273,7 @@ describe("Simple Dataset tests", () => {
       .end((err, res) => {
         if (err) return done(err);
         res.body.should.be.an("array");
-        res.body[0].scientificMetadata.runNumber.value.should.eql(10);
+        res.body[0].scientificMetadata.runNumber.value.should.eql(3);
         done();
       });
   });

--- a/test/Dataset.js
+++ b/test/Dataset.js
@@ -32,7 +32,8 @@ const testdataset = {
   "accessGroups": [],
   "datasetName":"Example Data86",
   "history": ["this should be deleted"],
-  "createdBy": "this should be deleted as well"
+  "createdBy": "this should be deleted as well",
+  "scientificMetadata": { "runNumber": 3 }
 };
 
 let app;
@@ -218,18 +219,6 @@ describe("Simple Dataset tests", () => {
       });
   });
 
-  it("should delete this dataset", function(done) {
-    request(app)
-      .delete("/api/v3/Datasets/" + pid + "?access_token=" + accessTokenArchiveManager)
-      .set("Accept", "application/json")
-      .expect(200)
-      .expect("Content-Type", /json/)
-      .end((err, _res) => {
-        if (err) return done(err);
-        done();
-      });
-  });
-
   it("fetches array of Datasets", function(done) {
     request(app)
       .get(
@@ -260,7 +249,10 @@ describe("Simple Dataset tests", () => {
   });
 
   it("should fetch a filtered array of datasets", function (done) {
-    const query = JSON.stringify({ isPublished: false, text: "test" });
+    const query = JSON.stringify({ 
+      isPublished: false, 
+      "scientific":[{ "lhs":"runNumber","relation":"GREATER_THAN","rhs": 3, "unit": "" }]
+    });
     const limits = JSON.stringify({
       skip: 0,
       limit: 3,
@@ -281,6 +273,19 @@ describe("Simple Dataset tests", () => {
       .end((err, res) => {
         if (err) return done(err);
         res.body.should.be.an("array");
+        res.body[0].scientificMetadata.runNumber.value.should.eql(10);
+        done();
+      });
+  });
+
+  it("should delete this dataset", function(done) {
+    request(app)
+      .delete("/api/v3/Datasets/" + pid + "?access_token=" + accessTokenArchiveManager)
+      .set("Accept", "application/json")
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .end((err, _res) => {
+        if (err) return done(err);
         done();
       });
   });


### PR DESCRIPTION
## Description

Allow filtering on computed fields

## Motivation

At PSI we allow runNumber to either be an object or a number. This allows the ordering and filtering to work in both cases

## Changes:

* common/models/mongo-queryable.js add computed field which replaces runNumber.value in aggregation pipeline

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
