### PR TITLE
OIDC session on mongo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@snyk/protect": "^1.936.0",
                 "amqplib": "^0.9.0",
                 "compression": "^1.7.4",
+                "connect-mongo": "^5.0.0",
                 "cors": "^2.8.5",
                 "express-session": "^1.17.3",
                 "gelf-pro": "^1.3.7",
@@ -194,6 +195,214 @@
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
             "dev": true
         },
+        "node_modules/@napi-rs/snappy-android-arm-eabi": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm-eabi/-/snappy-android-arm-eabi-7.2.2.tgz",
+            "integrity": "sha512-H7DuVkPCK5BlAr1NfSU8bDEN7gYs+R78pSHhDng83QxRnCLmVIZk33ymmIwurmoA1HrdTxbkbuNl+lMvNqnytw==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-android-arm64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm64/-/snappy-android-arm64-7.2.2.tgz",
+            "integrity": "sha512-2R/A3qok+nGtpVK8oUMcrIi5OMDckGYNoBLFyli3zp8w6IArPRfg1yOfVUcHvpUDTo9T7LOS1fXgMOoC796eQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-darwin-arm64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-arm64/-/snappy-darwin-arm64-7.2.2.tgz",
+            "integrity": "sha512-USgArHbfrmdbuq33bD5ssbkPIoT7YCXCRLmZpDS6dMDrx+iM7eD2BecNbOOo7/v1eu6TRmQ0xOzeQ6I/9FIi5g==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-darwin-x64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-x64/-/snappy-darwin-x64-7.2.2.tgz",
+            "integrity": "sha512-0APDu8iO5iT0IJKblk2lH0VpWSl9zOZndZKnBYIc+ei1npw2L5QvuErFOTeTdHBtzvUHASB+9bvgaWnQo4PvTQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-freebsd-x64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-freebsd-x64/-/snappy-freebsd-x64-7.2.2.tgz",
+            "integrity": "sha512-mRTCJsuzy0o/B0Hnp9CwNB5V6cOJ4wedDTWEthsdKHSsQlO7WU9W1yP7H3Qv3Ccp/ZfMyrmG98Ad7u7lG58WXA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-linux-arm-gnueabihf": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm-gnueabihf/-/snappy-linux-arm-gnueabihf-7.2.2.tgz",
+            "integrity": "sha512-v1uzm8+6uYjasBPcFkv90VLZ+WhLzr/tnfkZ/iD9mHYiULqkqpRuC8zvc3FZaJy5wLQE9zTDkTJN1IvUcZ+Vcg==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-linux-arm64-gnu": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-gnu/-/snappy-linux-arm64-gnu-7.2.2.tgz",
+            "integrity": "sha512-LrEMa5pBScs4GXWOn6ZYXfQ72IzoolZw5txqUHVGs8eK4g1HR9HTHhb2oY5ySNaKakG5sOgMsb1rwaEnjhChmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-linux-arm64-musl": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-musl/-/snappy-linux-arm64-musl-7.2.2.tgz",
+            "integrity": "sha512-3orWZo9hUpGQcB+3aTLW7UFDqNCQfbr0+MvV67x8nMNYj5eAeUtMmUE/HxLznHO4eZ1qSqiTwLbVx05/Socdlw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-linux-x64-gnu": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-gnu/-/snappy-linux-x64-gnu-7.2.2.tgz",
+            "integrity": "sha512-jZt8Jit/HHDcavt80zxEkDpH+R1Ic0ssiVCoueASzMXa7vwPJeF4ZxZyqUw4qeSy7n8UUExomu8G8ZbP6VKhgw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-linux-x64-musl": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-musl/-/snappy-linux-x64-musl-7.2.2.tgz",
+            "integrity": "sha512-Dh96IXgcZrV39a+Tej/owcd9vr5ihiZ3KRix11rr1v0MWtVb61+H1GXXlz6+Zcx9y8jM1NmOuiIuJwkV4vZ4WA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-win32-arm64-msvc": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-arm64-msvc/-/snappy-win32-arm64-msvc-7.2.2.tgz",
+            "integrity": "sha512-9No0b3xGbHSWv2wtLEn3MO76Yopn1U2TdemZpCaEgOGccz1V+a/1d16Piz3ofSmnA13HGFz3h9NwZH9EOaIgYA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-win32-ia32-msvc": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-ia32-msvc/-/snappy-win32-ia32-msvc-7.2.2.tgz",
+            "integrity": "sha512-QiGe+0G86J74Qz1JcHtBwM3OYdTni1hX1PFyLRo3HhQUSpmi13Bzc1En7APn+6Pvo7gkrcy81dObGLDSxFAkQQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/snappy-win32-x64-msvc": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-x64-msvc/-/snappy-win32-x64-msvc-7.2.2.tgz",
+            "integrity": "sha512-a43cyx1nK0daw6BZxVcvDEXxKMFLSBSDTAhsFD0VqSKcC7MGUBMaqyoWUcMiI7LBSz4bxUmxDWKfCYzpEmeb3w==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@sinonjs/commons": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -345,6 +554,22 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+            "peer": true
+        },
+        "node_modules/@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
+        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -489,9 +714,9 @@
             "optional": true
         },
         "node_modules/are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
             "optional": true,
             "dependencies": {
                 "delegates": "^1.0.0",
@@ -501,13 +726,13 @@
         "node_modules/are-we-there-yet/node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "optional": true
         },
         "node_modules/are-we-there-yet/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "optional": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -566,6 +791,17 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dependencies": {
                 "safer-buffer": "~2.1.0"
+            }
+        },
+        "node_modules/asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "node_modules/assert-plus": {
@@ -781,6 +1017,11 @@
             "resolved": "https://registry.npmjs.org/bluebird-defer/-/bluebird-defer-1.0.0.tgz",
             "integrity": "sha1-PqDhnzJoXs+4JCE1Q9qtA4wsovU="
         },
+        "node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
         "node_modules/body-parser": {
             "version": "1.19.0",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -898,7 +1139,7 @@
         "node_modules/buffer-fill": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
             "optional": true
         },
         "node_modules/buffer-more-ints": {
@@ -1375,10 +1616,47 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
+        "node_modules/connect-mongo": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.0.0.tgz",
+            "integrity": "sha512-s93jiP6GkRApn5duComx6RLwtP23YrulPxShz+8peX7svd6Q+MS8nKLhKCCazbP92C13eTVaIOxgeLt0ezIiCg==",
+            "dependencies": {
+                "debug": "^4.3.1",
+                "kruptein": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=12.9.0"
+            },
+            "peerDependencies": {
+                "express-session": "^1.17.1",
+                "mongodb": "^5.1.0"
+            }
+        },
+        "node_modules/connect-mongo/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/connect-mongo/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "node_modules/console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "optional": true
         },
         "node_modules/content-disposition": {
@@ -1520,7 +1798,7 @@
         "node_modules/decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
             "optional": true,
             "dependencies": {
                 "mimic-response": "^1.0.0"
@@ -1606,7 +1884,7 @@
         "node_modules/detect-libc": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
             "optional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
@@ -2670,7 +2948,7 @@
         "node_modules/gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
             "optional": true,
             "dependencies": {
                 "aproba": "^1.0.3",
@@ -2756,7 +3034,7 @@
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "optional": true
         },
         "node_modules/glob": {
@@ -3329,6 +3607,12 @@
                 "url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
             }
         },
+        "node_modules/ip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+            "peer": true
+        },
         "node_modules/ip-regex": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -3861,6 +4145,18 @@
                 "snappy": "^6.0.1"
             }
         },
+        "node_modules/kafka-node/node_modules/snappy": {
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.3.5.tgz",
+            "integrity": "sha512-lonrUtdp1b1uDn1dbwgQbBsb5BbaiLeKq+AGwOk2No+en+VvJThwmtztwulEQsLinRF681pBqib0NUZaizKLIA==",
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "bindings": "^1.3.1",
+                "nan": "^2.14.1",
+                "prebuild-install": "5.3.0"
+            }
+        },
         "node_modules/kafka-node/node_modules/uuid": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -3876,6 +4172,17 @@
             "integrity": "sha512-+Rcfu2hyQ/jv5skqRY8xA7Ra+mmRkDAzCaLDYbkGtgsNKpzxPWiLbk8ub0dgr4EbWrN1Zb4BCXHUkD6+zYfdWg==",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/kruptein": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.6.tgz",
+            "integrity": "sha512-EQJjTwAJfQkC4NfdQdo3HXM2a9pmBm8oidzH270cYu1MbgXPNPMJuldN7OPX+qdhPO5rw4X3/iKz0BFBfkXGKA==",
+            "dependencies": {
+                "asn1.js": "^5.4.1"
+            },
+            "engines": {
+                "node": ">8"
             }
         },
         "node_modules/lcid": {
@@ -4400,6 +4707,44 @@
                 "node": ">=10"
             }
         },
+        "node_modules/loopback-connector-mongodb/node_modules/mongodb": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+            "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+            "dependencies": {
+                "bl": "^2.2.1",
+                "bson": "^1.1.4",
+                "denque": "^1.4.1",
+                "optional-require": "^1.1.8",
+                "safe-buffer": "^5.1.2"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "optionalDependencies": {
+                "saslprep": "^1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws4": {
+                    "optional": true
+                },
+                "bson-ext": {
+                    "optional": true
+                },
+                "kerberos": {
+                    "optional": true
+                },
+                "mongodb-client-encryption": {
+                    "optional": true
+                },
+                "mongodb-extjson": {
+                    "optional": true
+                },
+                "snappy": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/loopback-connector-mongodb/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4803,6 +5148,11 @@
                 "node": ">=4"
             }
         },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
         "node_modules/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5008,41 +5358,55 @@
             }
         },
         "node_modules/mongodb": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.1.tgz",
-            "integrity": "sha512-iSVgexYr8ID0ieeNFUbRfQeOZxOchRck6kEDVySQRaa8VIw/1Pm+/LgcpZcl/BWV6nT0L8lP9qyl7dRPJ6mnLw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+            "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
+            "peer": true,
             "dependencies": {
-                "bl": "^2.2.1",
-                "bson": "^1.1.4",
-                "denque": "^1.4.1",
-                "optional-require": "^1.0.3",
-                "safe-buffer": "^5.1.2"
+                "bson": "^5.2.0",
+                "mongodb-connection-string-url": "^2.6.0",
+                "socks": "^2.7.1"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=14.20.1"
             },
             "optionalDependencies": {
-                "saslprep": "^1.0.0"
+                "saslprep": "^1.0.3"
+            },
+            "peerDependencies": {
+                "@aws-sdk/credential-providers": "^3.201.0",
+                "mongodb-client-encryption": ">=2.3.0 <3",
+                "snappy": "^7.2.2"
             },
             "peerDependenciesMeta": {
-                "aws4": {
-                    "optional": true
-                },
-                "bson-ext": {
-                    "optional": true
-                },
-                "kerberos": {
+                "@aws-sdk/credential-providers": {
                     "optional": true
                 },
                 "mongodb-client-encryption": {
                     "optional": true
                 },
-                "mongodb-extjson": {
-                    "optional": true
-                },
                 "snappy": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "peer": true,
+            "dependencies": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
+            }
+        },
+        "node_modules/mongodb/node_modules/bson": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
+            "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==",
+            "peer": true,
+            "engines": {
+                "node": ">=14.20.1"
             }
         },
         "node_modules/monologue.js": {
@@ -5356,9 +5720,9 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
-            "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
             "optional": true,
             "dependencies": {
                 "semver": "^5.4.1"
@@ -5650,7 +6014,7 @@
         "node_modules/noop-logger": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+            "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==",
             "optional": true
         },
         "node_modules/nopt": {
@@ -6893,6 +7257,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "peer": true,
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
         "node_modules/smtp-connection": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
@@ -6903,15 +7277,46 @@
             }
         },
         "node_modules/snappy": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.3.5.tgz",
-            "integrity": "sha512-lonrUtdp1b1uDn1dbwgQbBsb5BbaiLeKq+AGwOk2No+en+VvJThwmtztwulEQsLinRF681pBqib0NUZaizKLIA==",
-            "hasInstallScript": true,
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/snappy/-/snappy-7.2.2.tgz",
+            "integrity": "sha512-iADMq1kY0v3vJmGTuKcFWSXt15qYUz7wFkArOrsSg0IFfI3nJqIJvK2/ZbEIndg7erIJLtAVX2nSOqPz7DcwbA==",
             "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "optionalDependencies": {
+                "@napi-rs/snappy-android-arm-eabi": "7.2.2",
+                "@napi-rs/snappy-android-arm64": "7.2.2",
+                "@napi-rs/snappy-darwin-arm64": "7.2.2",
+                "@napi-rs/snappy-darwin-x64": "7.2.2",
+                "@napi-rs/snappy-freebsd-x64": "7.2.2",
+                "@napi-rs/snappy-linux-arm-gnueabihf": "7.2.2",
+                "@napi-rs/snappy-linux-arm64-gnu": "7.2.2",
+                "@napi-rs/snappy-linux-arm64-musl": "7.2.2",
+                "@napi-rs/snappy-linux-x64-gnu": "7.2.2",
+                "@napi-rs/snappy-linux-x64-musl": "7.2.2",
+                "@napi-rs/snappy-win32-arm64-msvc": "7.2.2",
+                "@napi-rs/snappy-win32-ia32-msvc": "7.2.2",
+                "@napi-rs/snappy-win32-x64-msvc": "7.2.2"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "peer": true,
             "dependencies": {
-                "bindings": "^1.3.1",
-                "nan": "^2.14.1",
-                "prebuild-install": "5.3.0"
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0",
+                "npm": ">= 3.0.0"
             }
         },
         "node_modules/source-map": {
@@ -7821,13 +8226,13 @@
         "node_modules/tar-stream/node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "optional": true
         },
         "node_modules/tar-stream/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "optional": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -7839,7 +8244,7 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "node_modules/tar-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+        "node_modules/tar-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
@@ -7853,12 +8258,6 @@
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
-        },
-        "node_modules/tar-stream/node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "optional": true
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -7961,6 +8360,18 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "peer": true,
+            "dependencies": {
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/traverse": {
@@ -8231,6 +8642,28 @@
                 "extsprintf": "^1.2.0"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "peer": true,
+            "dependencies": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/when": {
             "version": "3.7.8",
             "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
@@ -8273,10 +8706,13 @@
             "dev": true
         },
         "node_modules/which-pm-runs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-            "optional": true
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+            "optional": true,
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/whistlepunk": {
             "version": "0.3.3",
@@ -8729,6 +9165,97 @@
                 }
             }
         },
+        "@napi-rs/snappy-android-arm-eabi": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm-eabi/-/snappy-android-arm-eabi-7.2.2.tgz",
+            "integrity": "sha512-H7DuVkPCK5BlAr1NfSU8bDEN7gYs+R78pSHhDng83QxRnCLmVIZk33ymmIwurmoA1HrdTxbkbuNl+lMvNqnytw==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-android-arm64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm64/-/snappy-android-arm64-7.2.2.tgz",
+            "integrity": "sha512-2R/A3qok+nGtpVK8oUMcrIi5OMDckGYNoBLFyli3zp8w6IArPRfg1yOfVUcHvpUDTo9T7LOS1fXgMOoC796eQw==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-darwin-arm64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-arm64/-/snappy-darwin-arm64-7.2.2.tgz",
+            "integrity": "sha512-USgArHbfrmdbuq33bD5ssbkPIoT7YCXCRLmZpDS6dMDrx+iM7eD2BecNbOOo7/v1eu6TRmQ0xOzeQ6I/9FIi5g==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-darwin-x64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-x64/-/snappy-darwin-x64-7.2.2.tgz",
+            "integrity": "sha512-0APDu8iO5iT0IJKblk2lH0VpWSl9zOZndZKnBYIc+ei1npw2L5QvuErFOTeTdHBtzvUHASB+9bvgaWnQo4PvTQ==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-freebsd-x64": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-freebsd-x64/-/snappy-freebsd-x64-7.2.2.tgz",
+            "integrity": "sha512-mRTCJsuzy0o/B0Hnp9CwNB5V6cOJ4wedDTWEthsdKHSsQlO7WU9W1yP7H3Qv3Ccp/ZfMyrmG98Ad7u7lG58WXA==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-linux-arm-gnueabihf": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm-gnueabihf/-/snappy-linux-arm-gnueabihf-7.2.2.tgz",
+            "integrity": "sha512-v1uzm8+6uYjasBPcFkv90VLZ+WhLzr/tnfkZ/iD9mHYiULqkqpRuC8zvc3FZaJy5wLQE9zTDkTJN1IvUcZ+Vcg==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-linux-arm64-gnu": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-gnu/-/snappy-linux-arm64-gnu-7.2.2.tgz",
+            "integrity": "sha512-LrEMa5pBScs4GXWOn6ZYXfQ72IzoolZw5txqUHVGs8eK4g1HR9HTHhb2oY5ySNaKakG5sOgMsb1rwaEnjhChmQ==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-linux-arm64-musl": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-musl/-/snappy-linux-arm64-musl-7.2.2.tgz",
+            "integrity": "sha512-3orWZo9hUpGQcB+3aTLW7UFDqNCQfbr0+MvV67x8nMNYj5eAeUtMmUE/HxLznHO4eZ1qSqiTwLbVx05/Socdlw==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-linux-x64-gnu": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-gnu/-/snappy-linux-x64-gnu-7.2.2.tgz",
+            "integrity": "sha512-jZt8Jit/HHDcavt80zxEkDpH+R1Ic0ssiVCoueASzMXa7vwPJeF4ZxZyqUw4qeSy7n8UUExomu8G8ZbP6VKhgw==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-linux-x64-musl": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-musl/-/snappy-linux-x64-musl-7.2.2.tgz",
+            "integrity": "sha512-Dh96IXgcZrV39a+Tej/owcd9vr5ihiZ3KRix11rr1v0MWtVb61+H1GXXlz6+Zcx9y8jM1NmOuiIuJwkV4vZ4WA==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-win32-arm64-msvc": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-arm64-msvc/-/snappy-win32-arm64-msvc-7.2.2.tgz",
+            "integrity": "sha512-9No0b3xGbHSWv2wtLEn3MO76Yopn1U2TdemZpCaEgOGccz1V+a/1d16Piz3ofSmnA13HGFz3h9NwZH9EOaIgYA==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-win32-ia32-msvc": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-ia32-msvc/-/snappy-win32-ia32-msvc-7.2.2.tgz",
+            "integrity": "sha512-QiGe+0G86J74Qz1JcHtBwM3OYdTni1hX1PFyLRo3HhQUSpmi13Bzc1En7APn+6Pvo7gkrcy81dObGLDSxFAkQQ==",
+            "optional": true,
+            "peer": true
+        },
+        "@napi-rs/snappy-win32-x64-msvc": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-x64-msvc/-/snappy-win32-x64-msvc-7.2.2.tgz",
+            "integrity": "sha512-a43cyx1nK0daw6BZxVcvDEXxKMFLSBSDTAhsFD0VqSKcC7MGUBMaqyoWUcMiI7LBSz4bxUmxDWKfCYzpEmeb3w==",
+            "optional": true,
+            "peer": true
+        },
         "@sinonjs/commons": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -8874,6 +9401,22 @@
                 "@types/node": "*"
             }
         },
+        "@types/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+            "peer": true
+        },
+        "@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "peer": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -8986,9 +9529,9 @@
             "optional": true
         },
         "are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
             "optional": true,
             "requires": {
                 "delegates": "^1.0.0",
@@ -8998,13 +9541,13 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
                     "optional": true
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -9062,6 +9605,17 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
                 "safer-buffer": "~2.1.0"
+            }
+        },
+        "asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "assert-plus": {
@@ -9252,6 +9806,11 @@
             "resolved": "https://registry.npmjs.org/bluebird-defer/-/bluebird-defer-1.0.0.tgz",
             "integrity": "sha1-PqDhnzJoXs+4JCE1Q9qtA4wsovU="
         },
+        "bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
         "body-parser": {
             "version": "1.19.0",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -9353,7 +9912,7 @@
         "buffer-fill": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
             "optional": true
         },
         "buffer-more-ints": {
@@ -9751,10 +10310,34 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
+        "connect-mongo": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.0.0.tgz",
+            "integrity": "sha512-s93jiP6GkRApn5duComx6RLwtP23YrulPxShz+8peX7svd6Q+MS8nKLhKCCazbP92C13eTVaIOxgeLt0ezIiCg==",
+            "requires": {
+                "debug": "^4.3.1",
+                "kruptein": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "optional": true
         },
         "content-disposition": {
@@ -9871,7 +10454,7 @@
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
             "optional": true,
             "requires": {
                 "mimic-response": "^1.0.0"
@@ -9936,7 +10519,7 @@
         "detect-libc": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
             "optional": true
         },
         "diff": {
@@ -10766,7 +11349,7 @@
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
             "optional": true,
             "requires": {
                 "aproba": "^1.0.3",
@@ -10839,7 +11422,7 @@
         "github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "optional": true
         },
         "glob": {
@@ -11263,6 +11846,12 @@
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
             "integrity": "sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw=="
         },
+        "ip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+            "peer": true
+        },
         "ip-regex": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -11662,6 +12251,17 @@
                 "uuid": "^3.0.0"
             },
             "dependencies": {
+                "snappy": {
+                    "version": "6.3.5",
+                    "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.3.5.tgz",
+                    "integrity": "sha512-lonrUtdp1b1uDn1dbwgQbBsb5BbaiLeKq+AGwOk2No+en+VvJThwmtztwulEQsLinRF681pBqib0NUZaizKLIA==",
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.3.1",
+                        "nan": "^2.14.1",
+                        "prebuild-install": "5.3.0"
+                    }
+                },
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -11673,6 +12273,14 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-1.16.0.tgz",
             "integrity": "sha512-+Rcfu2hyQ/jv5skqRY8xA7Ra+mmRkDAzCaLDYbkGtgsNKpzxPWiLbk8ub0dgr4EbWrN1Zb4BCXHUkD6+zYfdWg=="
+        },
+        "kruptein": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.6.tgz",
+            "integrity": "sha512-EQJjTwAJfQkC4NfdQdo3HXM2a9pmBm8oidzH270cYu1MbgXPNPMJuldN7OPX+qdhPO5rw4X3/iKz0BFBfkXGKA==",
+            "requires": {
+                "asn1.js": "^5.4.1"
+            }
         },
         "lcid": {
             "version": "3.1.1",
@@ -12170,6 +12778,19 @@
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
                     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
                 },
+                "mongodb": {
+                    "version": "3.7.3",
+                    "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+                    "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+                    "requires": {
+                        "bl": "^2.2.1",
+                        "bson": "^1.1.4",
+                        "denque": "^1.4.1",
+                        "optional-require": "^1.1.8",
+                        "safe-buffer": "^5.1.2",
+                        "saslprep": "^1.0.0"
+                    }
+                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -12463,6 +13084,11 @@
             "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
             "optional": true
         },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -12622,16 +13248,33 @@
             }
         },
         "mongodb": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.1.tgz",
-            "integrity": "sha512-iSVgexYr8ID0ieeNFUbRfQeOZxOchRck6kEDVySQRaa8VIw/1Pm+/LgcpZcl/BWV6nT0L8lP9qyl7dRPJ6mnLw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+            "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
+            "peer": true,
             "requires": {
-                "bl": "^2.2.1",
-                "bson": "^1.1.4",
-                "denque": "^1.4.1",
-                "optional-require": "^1.0.3",
-                "safe-buffer": "^5.1.2",
-                "saslprep": "^1.0.0"
+                "bson": "^5.2.0",
+                "mongodb-connection-string-url": "^2.6.0",
+                "saslprep": "^1.0.3",
+                "socks": "^2.7.1"
+            },
+            "dependencies": {
+                "bson": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
+                    "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==",
+                    "peer": true
+                }
+            }
+        },
+        "mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "peer": true,
+            "requires": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
             }
         },
         "monologue.js": {
@@ -12926,9 +13569,9 @@
             }
         },
         "node-abi": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
-            "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
             "optional": true,
             "requires": {
                 "semver": "^5.4.1"
@@ -13170,7 +13813,7 @@
         "noop-logger": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+            "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==",
             "optional": true
         },
         "nopt": {
@@ -14118,6 +14761,12 @@
                 }
             }
         },
+        "smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "peer": true
+        },
         "smtp-connection": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
@@ -14128,14 +14777,35 @@
             }
         },
         "snappy": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.3.5.tgz",
-            "integrity": "sha512-lonrUtdp1b1uDn1dbwgQbBsb5BbaiLeKq+AGwOk2No+en+VvJThwmtztwulEQsLinRF681pBqib0NUZaizKLIA==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/snappy/-/snappy-7.2.2.tgz",
+            "integrity": "sha512-iADMq1kY0v3vJmGTuKcFWSXt15qYUz7wFkArOrsSg0IFfI3nJqIJvK2/ZbEIndg7erIJLtAVX2nSOqPz7DcwbA==",
             "optional": true,
+            "peer": true,
             "requires": {
-                "bindings": "^1.3.1",
-                "nan": "^2.14.1",
-                "prebuild-install": "5.3.0"
+                "@napi-rs/snappy-android-arm-eabi": "7.2.2",
+                "@napi-rs/snappy-android-arm64": "7.2.2",
+                "@napi-rs/snappy-darwin-arm64": "7.2.2",
+                "@napi-rs/snappy-darwin-x64": "7.2.2",
+                "@napi-rs/snappy-freebsd-x64": "7.2.2",
+                "@napi-rs/snappy-linux-arm-gnueabihf": "7.2.2",
+                "@napi-rs/snappy-linux-arm64-gnu": "7.2.2",
+                "@napi-rs/snappy-linux-arm64-musl": "7.2.2",
+                "@napi-rs/snappy-linux-x64-gnu": "7.2.2",
+                "@napi-rs/snappy-linux-x64-musl": "7.2.2",
+                "@napi-rs/snappy-win32-arm64-msvc": "7.2.2",
+                "@napi-rs/snappy-win32-ia32-msvc": "7.2.2",
+                "@napi-rs/snappy-win32-x64-msvc": "7.2.2"
+            }
+        },
+        "socks": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "peer": true,
+            "requires": {
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
             }
         },
         "source-map": {
@@ -14859,13 +15529,13 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
                     "optional": true
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -14875,15 +15545,13 @@
                         "safe-buffer": "~5.1.1",
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                            "optional": true
-                        }
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "optional": true
                 },
                 "string_decoder": {
                     "version": "1.1.1",
@@ -14892,14 +15560,6 @@
                     "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                            "optional": true
-                        }
                     }
                 }
             }
@@ -14985,6 +15645,15 @@
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
                 "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "peer": true,
+            "requires": {
                 "punycode": "^2.1.1"
             }
         },
@@ -15195,6 +15864,22 @@
                 "extsprintf": "^1.2.0"
             }
         },
+        "webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true
+        },
+        "whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "peer": true,
+            "requires": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+            }
+        },
         "when": {
             "version": "3.7.8",
             "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
@@ -15228,9 +15913,9 @@
             "dev": true
         },
         "which-pm-runs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
             "optional": true
         },
         "whistlepunk": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@snyk/protect": "^1.936.0",
         "amqplib": "^0.9.0",
         "compression": "^1.7.4",
+        "connect-mongo": "^5.0.0",
         "cors": "^2.8.5",
         "express-session": "^1.17.3",
         "gelf-pro": "^1.3.7",

--- a/server/server.js
+++ b/server/server.js
@@ -17,19 +17,6 @@ var passportConfigurator = new PassportConfigurator(app);
 
 var loginCallbacks = require("./boot/login-callbacks");
 
-// express sessions are required for passport ocid. If your
-// config.Local has a session for the expressionSecret, configure
-// express-session
-if (configLocal.expressSessionSecret){
-  var session = require("express-session");
-  app.use(session({
-    secret: configLocal.expressSessionSecret,
-    resave: false,
-    saveUninitialized: true
-  }));
-}
-
-
 // enhance the profile definition to allow for applying regexp based substitution rules to be applied
 // to the outcome of e.g. LDAP queries. This can for example be exploited to define the groups
 // a user belongs to by scanning the output of the memberOf fields of a user
@@ -217,6 +204,18 @@ passportConfigurator.setupModels({
   userCredentialModel: app.models.userCredential
 });
 
+// express sessions are required for passport ocid. If your
+// config.Local has a session for the expressionSecret, configure
+// express-session
+if (configLocal.expressSessionSecret){
+  var session = require("express-session");
+  app.use(session({
+    secret: configLocal.expressSessionSecret,
+    resave: false,
+    saveUninitialized: configLocal.expressSessionSaveUninitialized || true,
+    ...(configLocal.expressSessionStore? { store: require("./session-store").sessionStoreBuilder(app) }: {})
+  }));
+}
 
 
 // Configure passport strategies for third party auth providers

--- a/server/server.js
+++ b/server/server.js
@@ -140,7 +140,7 @@ if ("smtpSettings" in configLocal) {
 var bodyParser = require("body-parser");
 app.start = function() {
   // start the web server
-  return app.listen(function() {
+  const server = app.listen(function() {
     app.emit("started");
     var baseUrl = app.get("url").replace(/\/$/, "");
     console.log("Web server listening at: %s", baseUrl);
@@ -149,6 +149,9 @@ app.start = function() {
       console.log("Browse your REST API at %s%s", baseUrl, explorerPath);
     }
   });
+  if (configLocal.serverTimeout)
+    Object.entries(configLocal.serverTimeout).map(([k, v]) => server[k] = v);
+  return server;
 };
 
 // Bootstrap the application, configure models, datasources and middleware.
@@ -212,7 +215,9 @@ if (configLocal.expressSessionSecret){
   app.use(session({
     secret: configLocal.expressSessionSecret,
     resave: false,
-    saveUninitialized: configLocal.expressSessionSaveUninitialized || true,
+    saveUninitialized: configLocal.expressSessionSaveUninitialized === undefined?
+      true: 
+      configLocal.expressSessionSaveUninitialized,
     ...(configLocal.expressSessionStore? { store: require("./session-store").sessionStoreBuilder(app) }: {})
   }));
 }

--- a/server/session-store.js
+++ b/server/session-store.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const MongoStore = require("connect-mongo");
+
+exports.sessionStoreBuilder = (app) =>
+  MongoStore.create({
+    mongoUrl: app.datasources.mongo.settings.url
+  });


### PR DESCRIPTION
## Description

Store OIDC session on mongo to enable horizontal scaling
## Motivation

Horizontal scaling is useful when multiple instances of the same be are required, to manage bigger loads or decrease the downtime in case of failures. Since the OIDC login is stateful in the be, as it uses connect.sessionIds to follow the user login, such a session cannot be stored in memory if more than one be instance is running, as the login flow could potentially be initiated by one instance and finished in a second (which will then fail to find the session in its memory). Storing the session on mongo enables its sharing between the be instances

## Changes:

* mongo session
* includes setting the servers timeouts
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [x] New packages used/requires npm install? 
- [ ] Toggle added for new features?
